### PR TITLE
Proposal: Stoppable Iterator

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -466,6 +466,45 @@ func BenchmarkIter100Unsafe(b *testing.B) {
 	benchIter(b, 100, NewThreadUnsafeSet())
 }
 
+func benchIterator(b *testing.B, n int, s Set) {
+	nums := nrand(n)
+	for _, v := range nums {
+		s.Add(v)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c := s.Iterator().C
+		for _ = range c {
+
+		}
+	}
+}
+
+func BenchmarkIterator1Safe(b *testing.B) {
+	benchIterator(b, 1, NewSet())
+}
+
+func BenchmarkIterator1Unsafe(b *testing.B) {
+	benchIterator(b, 1, NewThreadUnsafeSet())
+}
+
+func BenchmarkIterator10Safe(b *testing.B) {
+	benchIterator(b, 10, NewSet())
+}
+
+func BenchmarkIterator10Unsafe(b *testing.B) {
+	benchIterator(b, 10, NewThreadUnsafeSet())
+}
+
+func BenchmarkIterator100Safe(b *testing.B) {
+	benchIterator(b, 100, NewSet())
+}
+
+func BenchmarkIterator100Unsafe(b *testing.B) {
+	benchIterator(b, 100, NewThreadUnsafeSet())
+}
+
 func benchString(b *testing.B, n int, s Set) {
 	nums := nrand(n)
 	for _, v := range nums {

--- a/iterator.go
+++ b/iterator.go
@@ -32,9 +32,7 @@ type Iterator struct {
 	stop chan struct{}
 }
 
-// Stop stops the Iterator, C will be closed.
-// Please note, that further values may be sent on C. Those have to be exhausted for the goroutine
-// can be garbage collected. Use as in the example, however, is safe.
+// Stop stops the Iterator, no further elements will be received on C, C will be closed.
 func (i *Iterator) Stop() {
 	// Allows for Stop() to be called multiple times
 	// (close() panics when called on already closed channel)
@@ -43,6 +41,10 @@ func (i *Iterator) Stop() {
 	}()
 
 	close(i.stop)
+
+	// Exhaust any remaining elements.
+	for _ = range i.C {
+	}
 }
 
 // newIterator returns a new Iterator instance together with its item and stop channels.

--- a/iterator.go
+++ b/iterator.go
@@ -1,0 +1,56 @@
+/*
+Open Source Initiative OSI - The MIT License (MIT):Licensing
+
+The MIT License (MIT)
+Copyright (c) 2013 Ralph Caraveo (deckarep@gmail.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package mapset
+
+// Iterator defines an iterator over a Set, its C channel can be used to range over the Set's
+// elements.
+type Iterator struct {
+	C    <-chan interface{}
+	stop chan struct{}
+}
+
+// Stop stops the Iterator, C will be closed.
+// Please note, that further values may be sent on C. Those have to be exhausted for the goroutine
+// can be garbage collected. Use as in the example, however, is safe.
+func (i *Iterator) Stop() {
+	// Allows for Stop() to be called multiple times
+	// (close() panics when called on already closed channel)
+	defer func() {
+		recover()
+	}()
+
+	close(i.stop)
+}
+
+// newIterator returns a new Iterator instance together with its item and stop channels.
+func newIterator() (*Iterator, chan<- interface{}, <-chan struct{}) {
+	itemChan := make(chan interface{})
+	stopChan := make(chan struct{})
+	return &Iterator{
+		C:    itemChan,
+		stop: stopChan,
+	}, itemChan, stopChan
+}

--- a/iterator_example_test.go
+++ b/iterator_example_test.go
@@ -1,0 +1,32 @@
+package mapset
+
+import (
+	"fmt"
+)
+
+type YourType struct {
+	Name string
+}
+
+func ExampleIterator() {
+	set := NewSetFromSlice([]interface{}{
+		&YourType{Name: "Alise"},
+		&YourType{Name: "Bob"},
+		&YourType{Name: "John"},
+		&YourType{Name: "Nick"},
+	})
+
+	var found *YourType = nil
+	it := set.Iterator()
+
+	for elem := range it.C {
+		if elem.(*YourType).Name == "John" {
+			found = elem.(*YourType)
+			it.Stop()
+		}
+	}
+
+	fmt.Printf("Found %+v\n", found)
+
+	// Output: Found &{Name:John}
+}

--- a/set.go
+++ b/set.go
@@ -106,6 +106,10 @@ type Set interface {
 	// range over.
 	Iter() <-chan interface{}
 
+	// Returns an Iterator object that you can
+	// use to range over the set.
+	Iterator() *Iterator
+
 	// Remove a single element from the set.
 	Remove(i interface{})
 

--- a/set_test.go
+++ b/set_test.go
@@ -728,7 +728,7 @@ func Test_UnsafeSetClone(t *testing.T) {
 	}
 }
 
-func Test_Iterator(t *testing.T) {
+func Test_Iter(t *testing.T) {
 	a := NewSet()
 
 	a.Add("Z")
@@ -742,11 +742,11 @@ func Test_Iterator(t *testing.T) {
 	}
 
 	if !a.Equal(b) {
-		t.Error("The sets are not equal after iterating through the first set")
+		t.Error("The sets are not equal after iterating (Iter) through the first set")
 	}
 }
 
-func Test_UnsafeIterator(t *testing.T) {
+func Test_UnsafeIter(t *testing.T) {
 	a := NewThreadUnsafeSet()
 
 	a.Add("Z")
@@ -760,7 +760,43 @@ func Test_UnsafeIterator(t *testing.T) {
 	}
 
 	if !a.Equal(b) {
-		t.Error("The sets are not equal after iterating through the first set")
+		t.Error("The sets are not equal after iterating (Iter) through the first set")
+	}
+}
+
+func Test_Iterator(t *testing.T) {
+	a := NewSet()
+
+	a.Add("Z")
+	a.Add("Y")
+	a.Add("X")
+	a.Add("W")
+
+	b := NewSet()
+	for val := range a.Iterator().C {
+		b.Add(val)
+	}
+
+	if !a.Equal(b) {
+		t.Error("The sets are not equal after iterating (Iterator) through the first set")
+	}
+}
+
+func Test_UnsafeIterator(t *testing.T) {
+	a := NewThreadUnsafeSet()
+
+	a.Add("Z")
+	a.Add("Y")
+	a.Add("X")
+	a.Add("W")
+
+	b := NewThreadUnsafeSet()
+	for val := range a.Iterator().C {
+		b.Add(val)
+	}
+
+	if !a.Equal(b) {
+		t.Error("The sets are not equal after iterating (Iterator) through the first set")
 	}
 }
 

--- a/set_test.go
+++ b/set_test.go
@@ -800,6 +800,21 @@ func Test_UnsafeIterator(t *testing.T) {
 	}
 }
 
+func Test_IteratorStop(t *testing.T) {
+	a := NewSet()
+
+	a.Add("Z")
+	a.Add("Y")
+	a.Add("X")
+	a.Add("W")
+
+	it := a.Iterator()
+	it.Stop()
+	for _ = range it.C {
+		t.Error("The iterating (Iterator) did not stop after Stop() has been called")
+	}
+}
+
 func Test_PowerSet(t *testing.T) {
 	a := NewThreadUnsafeSet()
 

--- a/threadunsafe.go
+++ b/threadunsafe.go
@@ -159,6 +159,24 @@ func (set *threadUnsafeSet) Iter() <-chan interface{} {
 	return ch
 }
 
+func (set *threadUnsafeSet) Iterator() *Iterator {
+	iterator, ch, stopCh := newIterator()
+
+	go func() {
+	L:
+		for elem := range *set {
+			select {
+			case <-stopCh:
+				break L
+			case ch <- elem:
+			}
+		}
+		close(ch)
+	}()
+
+	return iterator
+}
+
 func (set *threadUnsafeSet) Equal(other Set) bool {
 	_ = other.(*threadUnsafeSet)
 


### PR DESCRIPTION
A problem with the current `Iter()` method, that there is no way to stop it.
When breaking out of the `for ... range` loop early, the goroutine started by `Iter()` will hang around forever; thus forcing the user to always iterate over all elements.
When iterating over large sets, that introduces quite some overhead.

I propose an additional method returning a stoppable Iterator.

The implementation provided with this pull request uses a second `stop` channel and `select` statement to achieve that. 

Performance:
```
BenchmarkIter1Safe-8        	 2000000	       612 ns/op
BenchmarkIter1Unsafe-8      	 2000000	       616 ns/op
BenchmarkIter10Safe-8       	  500000	      2855 ns/op
BenchmarkIter10Unsafe-8     	  500000	      2931 ns/op
BenchmarkIter100Safe-8      	   50000	     24435 ns/op
BenchmarkIter100Unsafe-8    	  100000	     24598 ns/op
BenchmarkIterator1Safe-8    	 2000000	       870 ns/op
BenchmarkIterator1Unsafe-8  	 2000000	       856 ns/op
BenchmarkIterator10Safe-8   	  300000	      4799 ns/op
BenchmarkIterator10Unsafe-8 	  300000	      4768 ns/op
BenchmarkIterator100Safe-8  	   30000	     40895 ns/op
BenchmarkIterator100Unsafe-8	   30000	     40984 ns/op
```
Its performance does not justify using the Iterator for a simple linear search, but there are other use cases, e.g. getting a 10% sample, running a more expensive operation, ....

A note about the `for ... range` in the `Stop()` method:
> Unfortunately the Iterator does not always actually stop instantaneously after `Stop()` has been called: In about 50% of the cases at least one further element is send (due to the pseudo-random characteristics of `select`):
> (Read as no of times `[0 1 2 3 4 5 6 7 8 9]` elements were send after calling `Stop()`)
> ```
> n = 10000000
> max set card = 10
> [6571964 3427926 110 0 0 0 0 0 0 0]
> 
> n = 100000
> max set card = 1000
> [50249 49750 1 0 0 0 0 0 0 0]
> ```
> Hence, the channel is exhausted in the `Stop()` method
