### PR TITLE
Update set.go descriptions

### DIFF
--- a/set.go
+++ b/set.go
@@ -84,8 +84,8 @@ type Set interface {
 	// panic.
 	Intersect(other Set) Set
 
-	// Determines if every element in the other set
-	// is in this set.
+	// Determines if every element in this set is in
+	// the other set.
 	//
 	// Note that the argument to IsSubset
 	// must be of the same type as the receiver
@@ -93,8 +93,8 @@ type Set interface {
 	// panic.
 	IsSubset(other Set) bool
 
-	// Determines if every element in this set is in
-	// the other set.
+	// Determines if every element in the other set
+	// is in this set.
 	//
 	// Note that the argument to IsSuperset
 	// must be of the same type as the receiver


### PR DESCRIPTION
Descriptions of IsSuperset() and IsSubset() were reversed.

They are still incorrect on godoc.org.