### PR TITLE
Fixes deadlock in the ToSlice method.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: go
 
 go:
-    - 1.2
-    - 1.3
+    - 1.5
+    - 1.6
+    - 1.7
     - tip
 
 script:

--- a/threadsafe.go
+++ b/threadsafe.go
@@ -214,8 +214,8 @@ func (set *threadSafeSet) CartesianProduct(other Set) Set {
 }
 
 func (set *threadSafeSet) ToSlice() []interface{} {
-	set.RLock()
 	keys := make([]interface{}, 0, set.Cardinality())
+	set.RLock()
 	for elem := range set.s {
 		keys = append(keys, elem)
 	}

--- a/threadsafe_test.go
+++ b/threadsafe_test.go
@@ -376,6 +376,27 @@ func Test_ToSlice(t *testing.T) {
 	}
 }
 
+// Test_ToSliceDeadlock - fixes issue: https://github.com/deckarep/golang-set/issues/36
+// This code reveals the deadlock however it doesn't happen consistently.
+func Test_ToSliceDeadlock(t *testing.T) {
+	runtime.GOMAXPROCS(2)
+
+	var wg sync.WaitGroup
+	set := NewSet()
+	workers := 10
+	wg.Add(workers)
+	for i := 1; i <= workers; i++ {
+		go func() {
+			for j := 0; j < 1000; j++ {
+				set.Add(1)
+				set.ToSlice()
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+
 func Test_UnmarshalJSON(t *testing.T) {
 	s := []byte(`["test", 1, 2, 3, ["4,5,6"]]`)
 	expected := NewSetFromSlice(


### PR DESCRIPTION
## Summary
Fixes a deadlock in the ToSlice method.

Closes issue: https://github.com/deckarep/golang-set/issues/36