### PR TITLE
Exposed orderedPair (now OrderedPair) and its fields.

### DIFF
--- a/threadunsafe.go
+++ b/threadunsafe.go
@@ -35,18 +35,18 @@ import (
 
 type threadUnsafeSet map[interface{}]struct{}
 
-type orderedPair struct {
-	first  interface{}
-	second interface{}
+type OrderedPair struct {
+	First  interface{}
+	Second interface{}
 }
 
 func newThreadUnsafeSet() threadUnsafeSet {
 	return make(threadUnsafeSet)
 }
 
-func (pair *orderedPair) Equal(other orderedPair) bool {
-	if pair.first == other.first &&
-		pair.second == other.second {
+func (pair *OrderedPair) Equal(other OrderedPair) bool {
+	if pair.First == other.First &&
+		pair.Second == other.Second {
 		return true
 	}
 
@@ -210,8 +210,8 @@ func (set *threadUnsafeSet) String() string {
 	return fmt.Sprintf("Set{%s}", strings.Join(items, ", "))
 }
 
-func (pair orderedPair) String() string {
-	return fmt.Sprintf("(%v, %v)", pair.first, pair.second)
+func (pair OrderedPair) String() string {
+	return fmt.Sprintf("(%v, %v)", pair.First, pair.Second)
 }
 
 func (set *threadUnsafeSet) PowerSet() Set {
@@ -248,7 +248,7 @@ func (set *threadUnsafeSet) CartesianProduct(other Set) Set {
 
 	for i := range *set {
 		for j := range *o {
-			elem := orderedPair{first: i, second: j}
+			elem := OrderedPair{First: i, Second: j}
 			cartProduct.Add(elem)
 		}
 	}


### PR DESCRIPTION
As it is "orderedPair" is not exposed to users of this package. When taking the Cartesian product of sets, it's often necessary to work with and manipulate ordered pairs outside of the package golang-set. For example, when I'm working with the Cartesian product of two sets whose elements I know and I want to work with a particular element _in_ the Cartesian product set, there's no way to do so without having the orderedPair struct and its fields exposed to the user outside the package. This is a very simple change but one that I'd say is invaluable when working with sets that are Cartesian products of others.

(edit: I can give a more concrete example if needed. I was implementing finite automata, representing the set of states as, well, a set of strings, and the start state for a given DFA is a string in that set. To take the union of two DFAs, one often creates a DFA whose set of states is the Cartesian product of the two original ones, and whose start state is the ordered pair of the start states of the two original ones. Without exposing orderedPair to users, doing something like this becomes quite tricky.)