### PR TITLE
Include missing wg.Add and wg.Done calls

### DIFF
--- a/threadsafe_test.go
+++ b/threadsafe_test.go
@@ -138,8 +138,10 @@ func Test_ContainsConcurrent(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range ints {
+		wg.Add(1)
 		go func() {
 			s.Contains(interfaces...)
+			wg.Done()
 		}()
 	}
 	wg.Wait()
@@ -157,8 +159,10 @@ func Test_DifferenceConcurrent(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range ints {
+		wg.Add(1)
 		go func() {
 			s.Difference(ss)
+			wg.Done()
 		}()
 	}
 	wg.Wait()
@@ -176,8 +180,10 @@ func Test_EqualConcurrent(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range ints {
+		wg.Add(1)
 		go func() {
 			s.Equal(ss)
+			wg.Done()
 		}()
 	}
 	wg.Wait()
@@ -195,8 +201,10 @@ func Test_IntersectConcurrent(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range ints {
+		wg.Add(1)
 		go func() {
 			s.Intersect(ss)
+			wg.Done()
 		}()
 	}
 	wg.Wait()
@@ -214,8 +222,10 @@ func Test_IsSubsetConcurrent(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range ints {
+		wg.Add(1)
 		go func() {
 			s.IsSubset(ss)
+			wg.Done()
 		}()
 	}
 	wg.Wait()
@@ -233,8 +243,10 @@ func Test_IsSupersetConcurrent(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range ints {
+		wg.Add(1)
 		go func() {
 			s.IsSuperset(ss)
+			wg.Done()
 		}()
 	}
 	wg.Wait()
@@ -329,8 +341,10 @@ func Test_SymmetricDifferenceConcurrent(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range ints {
+		wg.Add(1)
 		go func() {
 			s.SymmetricDifference(ss)
+			wg.Done()
 		}()
 	}
 	wg.Wait()


### PR DESCRIPTION
Most of the functions in [`threadsafe_test.go`](https://github.com/deckarep/golang-set/blob/master/threadsafe_test.go) use [`sync.WaitGroup`](https://golang.org/pkg/sync/#WaitGroup) to synchronize.  However, seven of these neglect to increment or decrement the `WaitGroup` counter, thereby rendering the [`Wait`](https://golang.org/pkg/sync/#WaitGroup.Wait) useless.  This revision fils in the missing `wg.Add` and `wg.Done` calls.