### PR TITLE
Code comments and stylistic changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/deckarep/golang-set.svg?branch=master)](https://travis-ci.org/deckarep/golang-set)
+[![Go Report Card](https://goreportcard.com/badge/github.com/deckarep/golang-set)](https://goreportcard.com/report/github.com/deckarep/golang-set)
 [![GoDoc](https://godoc.org/github.com/deckarep/golang-set?status.svg)](http://godoc.org/github.com/deckarep/golang-set)
 
 ## golang-set

--- a/bench_test.go
+++ b/bench_test.go
@@ -286,6 +286,80 @@ func BenchmarkIsSuperset100Unsafe(b *testing.B) {
 	benchIsSuperset(b, 100, NewThreadUnsafeSet(), NewThreadUnsafeSet())
 }
 
+func benchIsProperSubset(b *testing.B, n int, s, t Set) {
+	nums := nrand(n)
+	for _, v := range nums {
+		s.Add(v)
+		t.Add(v)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.IsProperSubset(t)
+	}
+}
+
+func BenchmarkIsProperSubset1Safe(b *testing.B) {
+	benchIsProperSubset(b, 1, NewSet(), NewSet())
+}
+
+func BenchmarkIsProperSubset1Unsafe(b *testing.B) {
+	benchIsProperSubset(b, 1, NewThreadUnsafeSet(), NewThreadUnsafeSet())
+}
+
+func BenchmarkIsProperSubset10Safe(b *testing.B) {
+	benchIsProperSubset(b, 10, NewSet(), NewSet())
+}
+
+func BenchmarkIsProperSubset10Unsafe(b *testing.B) {
+	benchIsProperSubset(b, 10, NewThreadUnsafeSet(), NewThreadUnsafeSet())
+}
+
+func BenchmarkIsProperSubset100Safe(b *testing.B) {
+	benchIsProperSubset(b, 100, NewSet(), NewSet())
+}
+
+func BenchmarkIsProperSubset100Unsafe(b *testing.B) {
+	benchIsProperSubset(b, 100, NewThreadUnsafeSet(), NewThreadUnsafeSet())
+}
+
+func benchIsProperSuperset(b *testing.B, n int, s, t Set) {
+	nums := nrand(n)
+	for _, v := range nums {
+		s.Add(v)
+		t.Add(v)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.IsProperSuperset(t)
+	}
+}
+
+func BenchmarkIsProperSuperset1Safe(b *testing.B) {
+	benchIsProperSuperset(b, 1, NewSet(), NewSet())
+}
+
+func BenchmarkIsProperSuperset1Unsafe(b *testing.B) {
+	benchIsProperSuperset(b, 1, NewThreadUnsafeSet(), NewThreadUnsafeSet())
+}
+
+func BenchmarkIsProperSuperset10Safe(b *testing.B) {
+	benchIsProperSuperset(b, 10, NewSet(), NewSet())
+}
+
+func BenchmarkIsProperSuperset10Unsafe(b *testing.B) {
+	benchIsProperSuperset(b, 10, NewThreadUnsafeSet(), NewThreadUnsafeSet())
+}
+
+func BenchmarkIsProperSuperset100Safe(b *testing.B) {
+	benchIsProperSuperset(b, 100, NewSet(), NewSet())
+}
+
+func BenchmarkIsProperSuperset100Unsafe(b *testing.B) {
+	benchIsProperSuperset(b, 100, NewThreadUnsafeSet(), NewThreadUnsafeSet())
+}
+
 func BenchmarkDifference1Safe(b *testing.B) {
 	benchDifference(b, 1, NewSet(), NewSet())
 }

--- a/bench_test.go
+++ b/bench_test.go
@@ -587,7 +587,7 @@ func benchString(b *testing.B, n int, s Set) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		s.String()
+		_ = s.String()
 	}
 }
 

--- a/iterator_example_test.go
+++ b/iterator_example_test.go
@@ -16,7 +16,7 @@ func ExampleIterator() {
 		&YourType{Name: "Nick"},
 	})
 
-	var found *YourType = nil
+	var found *YourType
 	it := set.Iterator()
 
 	for elem := range it.C {

--- a/set.go
+++ b/set.go
@@ -42,7 +42,7 @@ type Set interface {
 	Cardinality() int
 
 	// Removes all elements from the set, leaving
-	// the emtpy set.
+	// the empty set.
 	Clear()
 
 	// Returns a clone of the set using the same

--- a/set.go
+++ b/set.go
@@ -85,6 +85,25 @@ type Set interface {
 	Intersect(other Set) Set
 
 	// Determines if every element in this set is in
+	// the other set but the two sets are not equal.
+	//
+	// Note that the argument to IsProperSubset
+	// must be of the same type as the receiver
+	// of the method. Otherwise, IsProperSubset
+	// will panic.
+	IsProperSubset(other Set) bool
+
+	// Determines if every element in the other set
+	// is in this set but the two sets are not
+	// equal.
+	//
+	// Note that the argument to IsSuperset
+	// must be of the same type as the receiver
+	// of the method. Otherwise, IsSuperset will
+	// panic.
+	IsProperSuperset(other Set) bool
+
+	// Determines if every element in this set is in
 	// the other set.
 	//
 	// Note that the argument to IsSubset

--- a/set.go
+++ b/set.go
@@ -28,11 +28,16 @@ SOFTWARE.
 // typical set operations: membership testing, intersection, union,
 // difference, symmetric difference and cloning.
 //
-// Package mapset provides two implementations. The default
-// implementation is safe for concurrent access. There is a non-threadsafe
-// implementation which is slightly more performant.
+// Package mapset provides two implementations of the Set
+// interface. The default implementation is safe for concurrent
+// access, but a non-thread-safe implementation is also provided for
+// programs that can benefit from the slight speed improvement and
+// that can enforce mutual exclusion through other means.
 package mapset
 
+// Set is the primary interface provided by the mapset package.  It
+// represents an unordered set of data and a large number of
+// operations that can be applied to that set.
 type Set interface {
 	// Adds an element to the set. Returns whether
 	// the item was added.
@@ -163,7 +168,8 @@ type Set interface {
 	ToSlice() []interface{}
 }
 
-// Creates and returns a reference to an empty set.
+// NewSet creates and returns a reference to an empty set.  Operations
+// on the resulting set are thread-safe.
 func NewSet(s ...interface{}) Set {
 	set := newThreadSafeSet()
 	for _, item := range s {
@@ -172,22 +178,29 @@ func NewSet(s ...interface{}) Set {
 	return &set
 }
 
-// Creates and returns a new set with the given elements
+// NewSetWith creates and returns a new set with the given elements.
+// Operations on the resulting set are thread-safe.
 func NewSetWith(elts ...interface{}) Set {
 	return NewSetFromSlice(elts)
 }
 
-// Creates and returns a reference to a set from an existing slice
+// NewSetFromSlice creates and returns a reference to a set from an
+// existing slice.  Operations on the resulting set are thread-safe.
 func NewSetFromSlice(s []interface{}) Set {
 	a := NewSet(s...)
 	return a
 }
 
+// NewThreadUnsafeSet creates and returns a reference to an empty set.
+// Operations on the resulting set are not thread-safe.
 func NewThreadUnsafeSet() Set {
 	set := newThreadUnsafeSet()
 	return &set
 }
 
+// NewThreadUnsafeSetFromSlice creates and returns a reference to a
+// set from an existing slice.  Operations on the resulting set are
+// not thread-safe.
 func NewThreadUnsafeSetFromSlice(s []interface{}) Set {
 	a := NewThreadUnsafeSet()
 	for _, item := range s {

--- a/set_test.go
+++ b/set_test.go
@@ -1031,7 +1031,7 @@ func Test_CartesianProduct(t *testing.T) {
 	d = empty.CartesianProduct(b)
 
 	if c.Cardinality() != 0 || d.Cardinality() != 0 {
-		t.Error("Cartesian product of any set and the emtpy set Ax0 || 0xA must be the empty set")
+		t.Error("Cartesian product of any set and the empty set Ax0 || 0xA must be the empty set")
 	}
 }
 

--- a/set_test.go
+++ b/set_test.go
@@ -327,6 +327,27 @@ func Test_SetIsSubset(t *testing.T) {
 	}
 }
 
+func Test_SetIsProperSubset(t *testing.T) {
+	a := makeSet([]int{1, 2, 3, 5, 7})
+	b := makeSet([]int{7, 5, 3, 2, 1})
+
+	if !a.IsSubset(b) {
+		t.Error("set a should be a subset of set b")
+	}
+	if a.IsProperSubset(b) {
+		t.Error("set a should not be a proper subset of set b (they're equal)")
+	}
+
+	b.Add(72)
+
+	if !a.IsSubset(b) {
+		t.Error("set a should be a subset of set b")
+	}
+	if !a.IsProperSubset(b) {
+		t.Error("set a should be a proper subset of set b")
+	}
+}
+
 func Test_UnsafeSetIsSubset(t *testing.T) {
 	a := makeUnsafeSet([]int{1, 2, 3, 5, 7})
 
@@ -346,7 +367,33 @@ func Test_UnsafeSetIsSubset(t *testing.T) {
 	}
 }
 
-func Test_SetIsSuperSet(t *testing.T) {
+func Test_UnsafeSetIsProperSubset(t *testing.T) {
+	a := makeUnsafeSet([]int{1, 2, 3, 5, 7})
+	b := NewThreadUnsafeSet()
+	b.Add(7)
+	b.Add(1)
+	b.Add(5)
+	b.Add(3)
+	b.Add(2)
+
+	if !a.IsSubset(b) {
+		t.Error("set a should be a subset of set b")
+	}
+	if a.IsProperSubset(b) {
+		t.Error("set a should not be a proper subset of set b (they're equal)")
+	}
+
+	b.Add(72)
+
+	if !a.IsSubset(b) {
+		t.Error("set a should be a subset of set b")
+	}
+	if !a.IsProperSubset(b) {
+		t.Error("set a should be a proper subset of set b because set b has 72")
+	}
+}
+
+func Test_SetIsSuperset(t *testing.T) {
 	a := NewSet()
 	a.Add(9)
 	a.Add(5)
@@ -366,11 +413,48 @@ func Test_SetIsSuperSet(t *testing.T) {
 	b.Add(42)
 
 	if a.IsSuperset(b) {
-		t.Error("set a should not be a superset of set b because set a has a 42")
+		t.Error("set a should not be a superset of set b because set b has a 42")
 	}
 }
 
-func Test_UnsafeSetIsSuperSet(t *testing.T) {
+func Test_SetIsProperSuperset(t *testing.T) {
+	a := NewSet()
+	a.Add(5)
+	a.Add(2)
+	a.Add(11)
+
+	b := NewSet()
+	b.Add(2)
+	b.Add(5)
+	b.Add(11)
+
+	if !a.IsSuperset(b) {
+		t.Error("set a should be a superset of set b")
+	}
+	if a.IsProperSuperset(b) {
+		t.Error("set a should not be a proper superset of set b (they're equal)")
+	}
+
+	a.Add(9)
+
+	if !a.IsSuperset(b) {
+		t.Error("set a should be a superset of set b")
+	}
+	if !a.IsProperSuperset(b) {
+		t.Error("set a not be a proper superset of set b because set a has a 9")
+	}
+
+	b.Add(42)
+
+	if a.IsSuperset(b) {
+		t.Error("set a should not be a superset of set b because set b has a 42")
+	}
+	if a.IsProperSuperset(b) {
+		t.Error("set a should not be a proper superset of set b because set b has a 42")
+	}
+}
+
+func Test_UnsafeSetIsSuperset(t *testing.T) {
 	a := NewThreadUnsafeSet()
 	a.Add(9)
 	a.Add(5)
@@ -391,6 +475,43 @@ func Test_UnsafeSetIsSuperSet(t *testing.T) {
 
 	if a.IsSuperset(b) {
 		t.Error("set a should not be a superset of set b because set a has a 42")
+	}
+}
+
+func Test_UnsafeSetIsProperSuperset(t *testing.T) {
+	a := NewThreadUnsafeSet()
+	a.Add(5)
+	a.Add(2)
+	a.Add(11)
+
+	b := NewThreadUnsafeSet()
+	b.Add(2)
+	b.Add(5)
+	b.Add(11)
+
+	if !a.IsSuperset(b) {
+		t.Error("set a should be a superset of set b")
+	}
+	if a.IsProperSuperset(b) {
+		t.Error("set a should not be a proper superset of set b (they're equal)")
+	}
+
+	a.Add(9)
+
+	if !a.IsSuperset(b) {
+		t.Error("set a should be a superset of set b")
+	}
+	if !a.IsProperSuperset(b) {
+		t.Error("set a not be a proper superset of set b because set a has a 9")
+	}
+
+	b.Add(42)
+
+	if a.IsSuperset(b) {
+		t.Error("set a should not be a superset of set b because set b has a 42")
+	}
+	if a.IsProperSuperset(b) {
+		t.Error("set a should not be a proper superset of set b because set b has a 42")
 	}
 }
 
@@ -426,7 +547,7 @@ func Test_SetUnion(t *testing.T) {
 
 	g := f.Union(e)
 	if g.Cardinality() != 8 {
-		t.Error("set g should still ahve 8 elements in it after being unioned with set f that has duplicates")
+		t.Error("set g should still have 8 elements in it after being unioned with set f that has duplicates")
 	}
 }
 
@@ -462,7 +583,7 @@ func Test_UnsafeSetUnion(t *testing.T) {
 
 	g := f.Union(e)
 	if g.Cardinality() != 8 {
-		t.Error("set g should still ahve 8 elements in it after being unioned with set f that has duplicates")
+		t.Error("set g should still have 8 elements in it after being unioned with set f that has duplicates")
 	}
 }
 

--- a/threadsafe.go
+++ b/threadsafe.go
@@ -62,8 +62,23 @@ func (set *threadSafeSet) IsSubset(other Set) bool {
 	return ret
 }
 
+func (set *threadSafeSet) IsProperSubset(other Set) bool {
+	o := other.(*threadSafeSet)
+
+	set.RLock()
+	defer set.RUnlock()
+	o.RLock()
+	defer o.RUnlock()
+
+	return set.s.IsProperSubset(&o.s)
+}
+
 func (set *threadSafeSet) IsSuperset(other Set) bool {
 	return other.IsSubset(set)
+}
+
+func (set *threadSafeSet) IsProperSuperset(other Set) bool {
+	return other.IsProperSubset(set)
 }
 
 func (set *threadSafeSet) Union(other Set) Set {

--- a/threadsafe_test.go
+++ b/threadsafe_test.go
@@ -231,6 +231,27 @@ func Test_IsSubsetConcurrent(t *testing.T) {
 	wg.Wait()
 }
 
+func Test_IsProperSubsetConcurrent(t *testing.T) {
+	runtime.GOMAXPROCS(2)
+
+	s, ss := NewSet(), NewSet()
+	ints := rand.Perm(N)
+	for _, v := range ints {
+		s.Add(v)
+		ss.Add(v)
+	}
+
+	var wg sync.WaitGroup
+	for range ints {
+		wg.Add(1)
+		go func() {
+			s.IsProperSubset(ss)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+
 func Test_IsSupersetConcurrent(t *testing.T) {
 	runtime.GOMAXPROCS(2)
 
@@ -246,6 +267,27 @@ func Test_IsSupersetConcurrent(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			s.IsSuperset(ss)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+
+func Test_IsProperSupersetConcurrent(t *testing.T) {
+	runtime.GOMAXPROCS(2)
+
+	s, ss := NewSet(), NewSet()
+	ints := rand.Perm(N)
+	for _, v := range ints {
+		s.Add(v)
+		ss.Add(v)
+	}
+
+	var wg sync.WaitGroup
+	for range ints {
+		wg.Add(1)
+		go func() {
+			s.IsProperSuperset(ss)
 			wg.Done()
 		}()
 	}

--- a/threadsafe_test.go
+++ b/threadsafe_test.go
@@ -364,7 +364,7 @@ func Test_StringConcurrent(t *testing.T) {
 	wg.Add(len(ints))
 	for range ints {
 		go func() {
-			s.String()
+			_ = s.String()
 			wg.Done()
 		}()
 	}

--- a/threadsafe_test.go
+++ b/threadsafe_test.go
@@ -138,8 +138,10 @@ func Test_ContainsConcurrent(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range ints {
+		wg.Add(1)
 		go func() {
 			s.Contains(interfaces...)
+			wg.Done()
 		}()
 	}
 	wg.Wait()
@@ -157,8 +159,10 @@ func Test_DifferenceConcurrent(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range ints {
+		wg.Add(1)
 		go func() {
 			s.Difference(ss)
+			wg.Done()
 		}()
 	}
 	wg.Wait()
@@ -176,8 +180,10 @@ func Test_EqualConcurrent(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range ints {
+		wg.Add(1)
 		go func() {
 			s.Equal(ss)
+			wg.Done()
 		}()
 	}
 	wg.Wait()
@@ -195,8 +201,10 @@ func Test_IntersectConcurrent(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range ints {
+		wg.Add(1)
 		go func() {
 			s.Intersect(ss)
+			wg.Done()
 		}()
 	}
 	wg.Wait()
@@ -214,8 +222,10 @@ func Test_IsSubsetConcurrent(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range ints {
+		wg.Add(1)
 		go func() {
 			s.IsSubset(ss)
+			wg.Done()
 		}()
 	}
 	wg.Wait()
@@ -233,8 +243,10 @@ func Test_IsSupersetConcurrent(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range ints {
+		wg.Add(1)
 		go func() {
 			s.IsSuperset(ss)
+			wg.Done()
 		}()
 	}
 	wg.Wait()
@@ -329,8 +341,10 @@ func Test_SymmetricDifferenceConcurrent(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range ints {
+		wg.Add(1)
 		go func() {
 			s.SymmetricDifference(ss)
+			wg.Done()
 		}()
 	}
 	wg.Wait()

--- a/threadunsafe.go
+++ b/threadunsafe.go
@@ -35,6 +35,7 @@ import (
 
 type threadUnsafeSet map[interface{}]struct{}
 
+// An OrderedPair represents a 2-tuple of values.
 type OrderedPair struct {
 	First  interface{}
 	Second interface{}
@@ -44,6 +45,7 @@ func newThreadUnsafeSet() threadUnsafeSet {
 	return make(threadUnsafeSet)
 }
 
+// Equal says whether two 2-tuples contain the same values in the same order.
 func (pair *OrderedPair) Equal(other OrderedPair) bool {
 	if pair.First == other.First &&
 		pair.Second == other.Second {
@@ -218,6 +220,7 @@ func (set *threadUnsafeSet) String() string {
 	return fmt.Sprintf("Set{%s}", strings.Join(items, ", "))
 }
 
+// String outputs a 2-tuple in the form "(A, B)".
 func (pair OrderedPair) String() string {
 	return fmt.Sprintf("(%v, %v)", pair.First, pair.Second)
 }

--- a/threadunsafe.go
+++ b/threadunsafe.go
@@ -78,8 +78,16 @@ func (set *threadUnsafeSet) IsSubset(other Set) bool {
 	return true
 }
 
+func (set *threadUnsafeSet) IsProperSubset(other Set) bool {
+	return set.IsSubset(other) && !set.Equal(other)
+}
+
 func (set *threadUnsafeSet) IsSuperset(other Set) bool {
 	return other.IsSubset(set)
+}
+
+func (set *threadUnsafeSet) IsProperSuperset(other Set) bool {
+	return set.IsSuperset(other) && !set.Equal(other)
 }
 
 func (set *threadUnsafeSet) Union(other Set) Set {


### PR DESCRIPTION
This revision incorporates a number of minor improvements to code and documentation quality.  The result passes [`go vet`](https://golang.org/cmd/vet/), [`misspell`](https://github.com/client9/misspell), and [`golint`](https://github.com/golang/lint).  To celebrate, the README file now includes a badge pointing to the [Go Report Card for golang-set](https://goreportcard.com/report/github.com/deckarep/golang-set).