### PR TITLE
Update Travis for 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-    - 1.7
     - 1.8
+    - 1.9
     - tip
 
 script:


### PR DESCRIPTION
This updates Travis to utilize Go 1.9 for builds...sucka.