### PR TITLE
[Feature Request]Add Each method for elements iteration

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -501,6 +501,44 @@ func BenchmarkUnion100Unsafe(b *testing.B) {
 	benchUnion(b, 100, NewThreadUnsafeSet(), NewThreadUnsafeSet())
 }
 
+func benchEach(b *testing.B, n int, s Set) {
+	nums := nrand(n)
+	for _, v := range nums {
+		s.Add(v)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.Each(func(elem interface{}) bool {
+			return false
+		})
+	}
+}
+
+func BenchmarkEach1Safe(b *testing.B) {
+	benchEach(b, 1, NewSet())
+}
+
+func BenchmarkEach1Unsafe(b *testing.B) {
+	benchEach(b, 1, NewThreadUnsafeSet())
+}
+
+func BenchmarkEach10Safe(b *testing.B) {
+	benchEach(b, 10, NewSet())
+}
+
+func BenchmarkEach10Unsafe(b *testing.B) {
+	benchEach(b, 10, NewThreadUnsafeSet())
+}
+
+func BenchmarkEach100Safe(b *testing.B) {
+	benchEach(b, 100, NewSet())
+}
+
+func BenchmarkEach100Unsafe(b *testing.B) {
+	benchEach(b, 100, NewThreadUnsafeSet())
+}
+
 func benchIter(b *testing.B, n int, s Set) {
 	nums := nrand(n)
 	for _, v := range nums {

--- a/set.go
+++ b/set.go
@@ -126,6 +126,10 @@ type Set interface {
 	// panic.
 	IsSuperset(other Set) bool
 
+	// Iterates over elements and executes the passed func against each element.
+	// If passed func returns true, stop iteration at the time.
+	Each(func(interface{}) bool)
+
 	// Returns a channel of elements that you can
 	// range over.
 	Iter() <-chan interface{}

--- a/set_test.go
+++ b/set_test.go
@@ -849,6 +849,37 @@ func Test_UnsafeSetClone(t *testing.T) {
 	}
 }
 
+func Test_Each(t *testing.T) {
+	a := NewSet()
+
+	a.Add("Z")
+	a.Add("Y")
+	a.Add("X")
+	a.Add("W")
+
+	b := NewSet()
+	a.Each(func(elem interface{}) bool {
+		b.Add(elem)
+		return false
+	})
+
+	if !a.Equal(b) {
+		t.Error("The sets are not equal after iterating (Each) through the first set")
+	}
+
+	var count int
+	a.Each(func(elem interface{}) bool {
+		if count == 2 {
+			return true
+		}
+		count++
+		return false
+	})
+	if count != 2 {
+		t.Error("Iteration should stop on the way")
+	}
+}
+
 func Test_Iter(t *testing.T) {
 	a := NewSet()
 

--- a/threadsafe.go
+++ b/threadsafe.go
@@ -151,6 +151,16 @@ func (set *threadSafeSet) Cardinality() int {
 	return len(set.s)
 }
 
+func (set *threadSafeSet) Each(cb func(interface{}) bool) {
+	set.RLock()
+	for elem := range set.s {
+		if cb(elem) {
+			break
+		}
+	}
+	set.RUnlock()
+}
+
 func (set *threadSafeSet) Iter() <-chan interface{} {
 	ch := make(chan interface{})
 	go func() {

--- a/threadunsafe.go
+++ b/threadunsafe.go
@@ -159,6 +159,14 @@ func (set *threadUnsafeSet) Cardinality() int {
 	return len(*set)
 }
 
+func (set *threadUnsafeSet) Each(cb func(interface{}) bool) {
+	for elem := range *set {
+		if cb(elem) {
+			break
+		}
+	}
+}
+
 func (set *threadUnsafeSet) Iter() <-chan interface{} {
 	ch := make(chan interface{})
 	go func() {


### PR DESCRIPTION
Hi.
Currently golang-set has Iter and Iteration method, but it is not necessary to return the channel in many cases that iterate elements.(Of course, sometimes it is necessary.) So I propose an iteration method that does not use channels or goroutines.

Each method is faster than Iter and Iterator. Benchmark is here: 
```
BenchmarkEach1Safe-4                            30000000                54.0 ns/op             0 B/op          0 allocs/op
BenchmarkEach1Unsafe-4                          30000000                45.1 ns/op             0 B/op          0 allocs/op
BenchmarkEach10Safe-4                           10000000               160 ns/op               0 B/op          0 allocs/op
BenchmarkEach10Unsafe-4                         10000000               155 ns/op               0 B/op          0 allocs/op
BenchmarkEach100Safe-4                           1000000              1449 ns/op               0 B/op          0 allocs/op
BenchmarkEach100Unsafe-4                         1000000              1500 ns/op               0 B/op          0 allocs/op
BenchmarkIter1Safe-4                             3000000               573 ns/op              96 B/op          1 allocs/op
BenchmarkIter1Unsafe-4                           3000000               552 ns/op              96 B/op          1 allocs/op
BenchmarkIter10Safe-4                             500000              2828 ns/op              96 B/op          1 allocs/op
BenchmarkIter10Unsafe-4                           500000              2779 ns/op              96 B/op          1 allocs/op
BenchmarkIter100Safe-4                            100000             25204 ns/op              96 B/op          1 allocs/op
BenchmarkIter100Unsafe-4                           50000             25880 ns/op              96 B/op          1 allocs/op
BenchmarkIterator1Safe-4                         2000000               779 ns/op             208 B/op          3 allocs/op
BenchmarkIterator1Unsafe-4                       2000000               797 ns/op             208 B/op          3 allocs/op
BenchmarkIterator10Safe-4                         300000              4483 ns/op             208 B/op          3 allocs/op
BenchmarkIterator10Unsafe-4                       300000              4486 ns/op             208 B/op          3 allocs/op
BenchmarkIterator100Safe-4                         30000             38857 ns/op             208 B/op          3 allocs/op
BenchmarkIterator100Unsafe-4                       30000             45187 ns/op             208 B/op          3 allocs/op
```