### PR TITLE
threadUnsafeSet: reduce allocation in Add func

### DIFF
--- a/threadunsafe.go
+++ b/threadunsafe.go
@@ -57,8 +57,12 @@ func (pair *OrderedPair) Equal(other OrderedPair) bool {
 
 func (set *threadUnsafeSet) Add(i interface{}) bool {
 	_, found := (*set)[i]
+	if found {
+		return false //False if it existed already
+	}
+
 	(*set)[i] = struct{}{}
-	return !found //False if it existed already
+	return true
 }
 
 func (set *threadUnsafeSet) Contains(i ...interface{}) bool {


### PR DESCRIPTION
In `Add` func, there's no need to alloc `struct{}` again if corresponding key-value pair exists.