### PR TITLE
Fix PowerSet return values

### DIFF
--- a/set_test.go
+++ b/set_test.go
@@ -1045,6 +1045,20 @@ func Test_PowerSet(t *testing.T) {
 	}
 }
 
+func Test_PowerSetThreadSafe(t *testing.T) {
+	set := NewSet().PowerSet()
+	_, setIsThreadSafe := set.(*threadSafeSet)
+	if !setIsThreadSafe {
+		t.Error("result of PowerSet should be thread safe")
+	}
+
+	subset := set.Pop()
+	_, subsetIsThreadSafe := subset.(*threadSafeSet)
+	if !subsetIsThreadSafe {
+		t.Error("subsets in PowerSet result should be thread safe")
+	}
+}
+
 func Test_EmptySetProperties(t *testing.T) {
 	empty := NewSet()
 

--- a/threadsafe.go
+++ b/threadsafe.go
@@ -226,8 +226,14 @@ func (set *threadSafeSet) String() string {
 
 func (set *threadSafeSet) PowerSet() Set {
 	set.RLock()
-	ret := set.s.PowerSet()
+	unsafePowerSet := set.s.PowerSet().(*threadUnsafeSet)
 	set.RUnlock()
+
+	ret := &threadSafeSet{s: newThreadUnsafeSet()}
+	for subset := range unsafePowerSet.Iter() {
+		unsafeSubset := subset.(*threadUnsafeSet)
+		ret.Add(&threadSafeSet{s: *unsafeSubset})
+	}
 	return ret
 }
 


### PR DESCRIPTION
Previously, calling `PowerSet()` on a `threadSafeSet` would return a `threadUnsafeSet` of `threadUnsafeSet`s. Now it returns a `threadSafeSet` of `threadSafeSet`s.

I found this issue while trying to use the results of `PowerSet()` in other functions, which panic on a `threadUnsafeSet`.