### PR TITLE
Add support for threadsafe element removal with reporting whether element was removed.

### DIFF
--- a/set.go
+++ b/set.go
@@ -141,6 +141,10 @@ type Set interface {
 	// Remove a single element from the set.
 	Remove(i interface{})
 
+	// Removes a single element from the set if it is present in the set.
+	// Returns whether the element was present in the set.
+	RemoveIfContains(i interface{}) bool
+
 	// Provides a convenient string representation
 	// of the current state of the set.
 	String() string

--- a/threadsafe.go
+++ b/threadsafe.go
@@ -145,6 +145,12 @@ func (set *threadSafeSet) Remove(i interface{}) {
 	set.Unlock()
 }
 
+func (set *threadSafeSet) RemoveIfContains(i interface{}) bool {
+	set.Lock()
+	defer set.Unlock()
+	return set.s.RemoveIfContains(i)
+}
+
 func (set *threadSafeSet) Cardinality() int {
 	set.RLock()
 	defer set.RUnlock()

--- a/threadunsafe.go
+++ b/threadunsafe.go
@@ -162,6 +162,14 @@ func (set *threadUnsafeSet) Remove(i interface{}) {
 	delete(*set, i)
 }
 
+func (set *threadUnsafeSet) RemoveIfContains(i interface{}) bool {
+	if set.Contains(i) {
+		delete(*set, i)
+		return true
+	}
+	return false
+}
+
 func (set *threadUnsafeSet) Cardinality() int {
 	return len(*set)
 }


### PR DESCRIPTION
An example use case for this is as follows:
Imagine we have a resource A that owns a set of resources of type B.
Both types have a public API to close the resource, where closing A implies closing all owned B.
B.Close() can be called only once, otherwise it will fail/panic.
Closing a B removes it from the set of resources that the parent A owns.

```
type A struct {
  setOfB Set
}
type B struct {}

func (a *A) CloseAllB()
func (b *B) Close()
```

To be able to avoid race conditions where two goroutines are calling A.CloseAllB() and B.Close() I would need to guarantee that I perform the business logic of B.Close() only when setOfB.Remove() actually removed the element. AFAIU current Set API doesn't allow me to determine this.

I welcome suggestions on how to name this new method (ideally I'd have Remove return the boolean, but that would be a backwards-incompatible change...)

I'll be happy to add tests if you agree that such an API should be added to this lib.