### PR TITLE
Travis-ci: added support for ppc64le and updated go versions 1.14 & 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: go
 
+arch:
+    - AMD64
+    - ppc64le
+
 go:
-    - 1.8
-    - 1.9
+    - 1.14
+    - 1.15
     - tip
 
 script:


### PR DESCRIPTION
Signed-off-by: Devendranath Thadi <devendranath.thadi3@gmail.com>

Added power support for the travis.yml file with ppc64le and updated latest go versions 1.14 & 1.15. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.
