### PR TITLE
Delete `New*SetFromSlice()` and `NewSetWith()` APIs

### DIFF
--- a/iterator_example_test.go
+++ b/iterator_example_test.go
@@ -35,12 +35,14 @@ type yourType struct {
 
 func Test_ExampleIterator(t *testing.T) {
 
-	s := NewSetFromSlice[*yourType]([]*yourType{
-		&yourType{name: "Alise"},
-		&yourType{name: "Bob"},
-		&yourType{name: "John"},
-		&yourType{name: "Nick"},
-	})
+	s := NewSet[*yourType](
+		[]*yourType{
+			&yourType{name: "Alise"},
+			&yourType{name: "Bob"},
+			&yourType{name: "John"},
+			&yourType{name: "Nick"},
+		}...,
+	)
 
 	var found *yourType
 	it := s.Iterator()

--- a/set.go
+++ b/set.go
@@ -185,19 +185,6 @@ func NewSet[T comparable](vals ...T) Set[T] {
 	return &s
 }
 
-// NewSetWith creates and returns a new set with the given elements.
-// Operations on the resulting set are thread-safe.
-func NewSetWith[T comparable](vals ...T) Set[T] {
-	return NewSetFromSlice(vals)
-}
-
-// NewSetFromSlice creates and returns a reference to a set from an
-// existing slice.  Operations on the resulting set are thread-safe.
-func NewSetFromSlice[T comparable](v []T) Set[T] {
-	s := NewSet(v...)
-	return s
-}
-
 // NewThreadUnsafeSet creates and returns a new set with the given elements.
 // Operations on the resulting set are not thread-safe.
 func NewThreadUnsafeSet[T comparable](vals ...T) Set[T] {
@@ -206,15 +193,4 @@ func NewThreadUnsafeSet[T comparable](vals ...T) Set[T] {
 		s.Add(item)
 	}
 	return &s
-}
-
-// NewThreadUnsafeSetFromSlice creates and returns a reference to a
-// set from an existing slice.  Operations on the resulting set are
-// not thread-safe.
-func NewThreadUnsafeSetFromSlice[T comparable](v []T) Set[T] {
-	s := NewThreadUnsafeSet[T]()
-	for _, item := range v {
-		s.Add(item)
-	}
-	return s
 }

--- a/set_test.go
+++ b/set_test.go
@@ -55,11 +55,11 @@ func Test_NewSet(t *testing.T) {
 		t.Error("NewSet should start out as an empty set")
 	}
 
-	assertEqual(NewSetFromSlice[int]([]int{}), NewSet[int](), t)
-	assertEqual(NewSetFromSlice[int]([]int{1}), NewSet[int](1), t)
-	assertEqual(NewSetFromSlice[int]([]int{1, 2}), NewSet[int](1, 2), t)
-	assertEqual(NewSetFromSlice[string]([]string{"a"}), NewSet[string]("a"), t)
-	assertEqual(NewSetFromSlice[string]([]string{"a", "b"}), NewSet[string]("a", "b"), t)
+	assertEqual(NewSet([]int{}...), NewSet[int](), t)
+	assertEqual(NewSet([]int{1}...), NewSet(1), t)
+	assertEqual(NewSet([]int{1, 2}...), NewSet(1, 2), t)
+	assertEqual(NewSet([]string{"a"}...), NewSet("a"), t)
+	assertEqual(NewSet([]string{"a", "b"}...), NewSet("a", "b"), t)
 }
 
 func Test_NewUnsafeSet(t *testing.T) {
@@ -1105,7 +1105,7 @@ func Test_Example(t *testing.T) {
 	   requiredClasses.Add("Biology")
 
 	   scienceSlice := []interface{}{"Biology", "Chemistry"}
-	   scienceClasses := NewSetFromSlice(scienceSlice)
+	   scienceClasses := NewSet(scienceSlice)
 
 	   electiveClasses := NewSet()
 	   electiveClasses.Add("Welding")

--- a/threadsafe_test.go
+++ b/threadsafe_test.go
@@ -473,13 +473,13 @@ func Test_ToSliceDeadlock(t *testing.T) {
 
 func Test_UnmarshalJSON(t *testing.T) {
 	s := []byte(`["test", "1", "2", "3"]`) //,["4,5,6"]]`)
-	expected := NewSetFromSlice(
+	expected := NewSet(
 		[]string{
 			string(json.Number("1")),
 			string(json.Number("2")),
 			string(json.Number("3")),
 			"test",
-		},
+		}...,
 	)
 
 	actual := NewSet[string]()
@@ -494,19 +494,19 @@ func Test_UnmarshalJSON(t *testing.T) {
 }
 
 func Test_MarshalJSON(t *testing.T) {
-	expected := NewSetFromSlice(
+	expected := NewSet(
 		[]string{
 			string(json.Number("1")),
 			"test",
-		},
+		}...,
 	)
 
 	b, err := json.Marshal(
-		NewSetFromSlice(
+		NewSet(
 			[]string{
 				"1",
 				"test",
-			},
+			}...,
 		),
 	)
 	if err != nil {


### PR DESCRIPTION
Builds on #83 , that should be merged first, then this.
--

These are no longer needed now that both `NewSet()` and
`NewThreadUnsafeSet()` accept optional vals.

Removing them simplifies the API surface, so that developers aren't left
scratching their heads wondering why there's both a `NewSet(vals ...T)`
and a `NewSetFromSlice()` that do the same thing.

Previously they couldn't be removed due to backwards compatibility
concerns, but with the `go 1.18` drop of generics, this library will be
cutting a new `v2` release, so a perfect time to cleanup this confusing
API as well.

Fix https://github.com/deckarep/golang-set/issues/78