### PR TITLE
Make `Remove()` return a bool indicating whether present

### DIFF
--- a/set.go
+++ b/set.go
@@ -138,8 +138,9 @@ type Set[T comparable] interface {
 	// use to range over the set.
 	Iterator() *Iterator[T]
 
-	// Remove a single element from the set.
-	Remove(i T)
+	// Remove a single element from the set if it is present in the set.
+	// Returns whether the element was present in the set.
+	Remove(i T) bool
 
 	// Provides a convenient string representation
 	// of the current state of the set.

--- a/threadsafe.go
+++ b/threadsafe.go
@@ -142,10 +142,10 @@ func (s *threadSafeSet[T]) Clear() {
 	s.Unlock()
 }
 
-func (s *threadSafeSet[T]) Remove(v T) {
+func (s *threadSafeSet[T]) Remove(v T) bool {
 	s.Lock()
-	delete(s.uss, v)
-	s.Unlock()
+	defer s.Unlock()
+	return s.uss.Remove(v)
 }
 
 func (s *threadSafeSet[T]) Cardinality() int {

--- a/threadunsafe.go
+++ b/threadunsafe.go
@@ -195,8 +195,12 @@ func (s *threadUnsafeSet[T]) Pop() (v T, ok bool) {
 	return
 }
 
-func (s *threadUnsafeSet[T]) Remove(v T) {
-	delete(*s, v)
+func (s *threadUnsafeSet[T]) Remove(v T) bool {
+	if s.Contains(v) {
+		delete(*s, v)
+		return true
+	}
+	return false
 }
 
 func (s *threadUnsafeSet[T]) String() string {


### PR DESCRIPTION
Make `Remove()` return a bool indicating whether the object was present.

This is useful for the thread-safe-set because the underlying mutex
isn't public, so without this it's impossible to know if the element was
originally present.

This is a tweak on https://github.com/deckarep/golang-set/pull/66.

This won't be a breaking change because today there's no returned value... 
so if there starts being a bool returned, legacy code will simply ignore it.

I'm sure this will have a minor perf hit, so putting this up to play
around with. If it's a super minor perf regression, then probably okay,
otherwise better to split `Remove()` from `RemoveWithResult()` or some
such API so that `Remove()` stays as high perf as possible.