### PR TITLE
fix README to use github.com/deckarep/golang-set/v2 to import module

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ package main
 
 import (
   "fmt"
-  mapset "github.com/deckarep/golang-set"
+  mapset "github.com/deckarep/golang-set/v2"
 )
 
 func main() {


### PR DESCRIPTION
I am not familiar with this repository, but I think we should use `github.com/deckarep/golang-set/v2` to import v2. So, fix README.