### PR TITLE
add wg.Wait() at the end of Test_CloneConcurrent

### DIFF
--- a/threadsafe_test.go
+++ b/threadsafe_test.go
@@ -122,8 +122,8 @@ func Test_CloneConcurrent(t *testing.T) {
 			wg.Done()
 		}(i)
 	}
-
 	s.Clone()
+	wg.Wait()
 }
 
 func Test_ContainsConcurrent(t *testing.T) {


### PR DESCRIPTION
I found that no `wg.Wait()` at the end of Test_CloneConcurrent. I just added it.