### PR TITLE
Default to latest patch version in CI, bump actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,17 +4,17 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18.0]
+        go-version: [1.18]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
         stable: false
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Test
       run: |
         go test -v -race ./...


### PR DESCRIPTION
1. Stop pinning patch version... IIUC the docs correctly, this will let it use whatever the latest patch version is.
2. Bump the actions versions `v3`. From a quick skim, none of the new changes really affect this workflow so it's safe to update. And since this is just CI, it should be quickly obvious if something is broken.