### PR TITLE
refactored Pop() function on threadUnsafeSet

### DIFF
--- a/threadunsafe.go
+++ b/threadunsafe.go
@@ -194,12 +194,12 @@ func (s *threadUnsafeSet[T]) Iterator() *Iterator[T] {
 }
 
 // TODO: how can we make this properly , return T but can't return nil.
-func (s *threadUnsafeSet[T]) Pop() (v T, ok bool) {
+func (s *threadUnsafeSet[T]) Pop() (T, bool) {
 	for item := range *s {
 		delete(*s, item)
 		return item, true
 	}
-	return
+	return *new(T), false
 }
 
 func (s *threadUnsafeSet[T]) Remove(v T) {


### PR DESCRIPTION
old
```go
func (s *threadUnsafeSet[T]) Pop() (v T, ok bool) {
	for item := range *s {
		delete(*s, item)
		return item, true
	}
	return
}
```
in my opinion, the last `return` badly impacts readability.

refactored
```go
func (s *threadUnsafeSet[T]) Pop() (T, bool) {
	for item := range *s {
		delete(*s, item)
		return item, true
	}
	return *new(T), false
}
```
- improved readability.
- no usage of named returns since they weren't actually used, they existed as a hack to return default values.

## test results
```
$ go test ./... -cover -race
ok      github.com/deckarep/golang-set/v2       79.012s coverage: 94.8% of statements
```