### PR TITLE
Release 2.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: 1.2
+        go-version: [1.20]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,21 +1,18 @@
+name: Go package
+
 on: [push, pull_request]
-name: CI
+
 jobs:
-  test:
-    strategy:
-      matrix:
-        go-version: [1.20]
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+  build:
+
+    runs-on: ubuntu-latest
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: ${{ matrix.go-version }}
-    - name: Checkout code
-      uses: actions/checkout@v3
-    - name: Test
-      run: |
-        go test -v -race ./...
-        # go vet ./...
-        # go test -bench=.
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.20
+
+      - name: Test
+        run: go test -v -race ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: 1.20
+        go-version: 1.2
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: 1.20.1
 
       - name: Test
         run: go test -v -race ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18]
+        go-version: [1.20]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,22 @@
-name: Go package
-
 on: [push, pull_request]
-
+name: CI
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
+  test:
+    strategy:
+      matrix:
+        go-version: [1.20.1]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.20.1
-
-      - name: Test
-        run: go test -v -race ./...
+    - name: Install Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: ${{ matrix.go-version }}
+        stable: false
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Test
+      run: |
+        go test -v -race ./...
+        # go vet ./...
+        # go test -bench=.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.20]
+        go-version: 1.20
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -12,7 +12,6 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
-        stable: false
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Test

--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@
 
 The missing `generic` set collection for the Go language.  Until Go has sets built-in...use this.
 
-## Update 3/26/2022
-* Packaged version: `2.0.0` release for generics support with breaking changes.
+## Update 3/5/2023
+* Packaged version: `2.2.0` release includes a refactor to minimize pointer indirection, better method documentation standards and a few constructor convenience methods to increase ergonomics when appending items `Append` or creating a new set from an exist `Map`.
 * supports `new generic` syntax
 * Go `1.18.0` or higher
+* Workflow tested on Go `1.20`
 
 ![With Generics](new_improved.jpeg)
 


### PR DESCRIPTION
- Workflow now test on Go version `1.20`
- Readme updated for this release
- New change minimizes pointer indirection
- New convenience methods for appending items or creating a set from a pre-existing map
- Better doc standards