### PR TITLE
Reintegrating optimizations originally proposed by @fy0 in issue: https://github.com/deckarep/golang-set/issues/60

### DIFF
--- a/set.go
+++ b/set.go
@@ -145,6 +145,9 @@ type Set[T comparable] interface {
 	// Remove removes a single element from the set.
 	Remove(i T)
 
+	// RemoveAll removes multiple elements from the set.
+	RemoveAll(i ...T)
+
 	// String provides a convenient string representation
 	// of the current state of the set.
 	String() string
@@ -182,27 +185,41 @@ type Set[T comparable] interface {
 // NewSet creates and returns a new set with the given elements.
 // Operations on the resulting set are thread-safe.
 func NewSet[T comparable](vals ...T) Set[T] {
-	s := newThreadSafeSet[T]()
+	s := newThreadSafeSetWithSize[T](len(vals))
 	for _, item := range vals {
 		s.Add(item)
 	}
+	return s
+}
+
+// NewSetWithSize creates and returns a reference to an empty set with a specified
+// capacity. Operations on the resulting set are thread-safe.
+func NewSetWithSize[T comparable](cardinality int) Set[T] {
+	s := newThreadSafeSetWithSize[T](cardinality)
 	return s
 }
 
 // NewThreadUnsafeSet creates and returns a new set with the given elements.
 // Operations on the resulting set are not thread-safe.
 func NewThreadUnsafeSet[T comparable](vals ...T) Set[T] {
-	s := newThreadUnsafeSet[T]()
+	s := newThreadUnsafeSetWithSize[T](len(vals))
 	for _, item := range vals {
 		s.Add(item)
 	}
 	return s
 }
 
-// Creates and returns a new set with the given keys of the map.
+// NewThreadUnsafeSetWithSize creates and returns a reference to an empty set with
+// a specified capacity. Operations on the resulting set are not thread-safe.
+func NewThreadUnsafeSetWithSize[T comparable](cardinality int) Set[T] {
+	s := newThreadUnsafeSetWithSize[T](cardinality)
+	return s
+}
+
+// NewSetFromMapKeys creates and returns a new set with the given keys of the map.
 // Operations on the resulting set are thread-safe.
 func NewSetFromMapKeys[T comparable, V any](val map[T]V) Set[T] {
-	s := NewSet[T]()
+	s := NewSetWithSize[T](len(val))
 
 	for k := range val {
 		s.Add(k)
@@ -211,10 +228,10 @@ func NewSetFromMapKeys[T comparable, V any](val map[T]V) Set[T] {
 	return s
 }
 
-// Creates and returns a new set with the given keys of the map.
+// NewThreadUnsafeSetFromMapKeys creates and returns a new set with the given keys of the map.
 // Operations on the resulting set are not thread-safe.
 func NewThreadUnsafeSetFromMapKeys[T comparable, V any](val map[T]V) Set[T] {
-	s := NewThreadUnsafeSet[T]()
+	s := NewThreadUnsafeSetWithSize[T](len(val))
 
 	for k := range val {
 		s.Add(k)

--- a/set_test.go
+++ b/set_test.go
@@ -185,6 +185,26 @@ func Test_RemoveSet(t *testing.T) {
 	}
 }
 
+func Test_RemoveAllSet(t *testing.T) {
+	a := makeSetInt([]int{6, 3, 1, 8, 9})
+
+	a.RemoveAll(3, 1)
+
+	if a.Cardinality() != 3 {
+		t.Error("RemoveAll should only have 2 items in the set")
+	}
+
+	if !a.Contains(6, 8, 9) {
+		t.Error("RemoveAll should have only items (6,8,9) in the set")
+	}
+
+	a.RemoveAll(6, 8, 9)
+
+	if a.Cardinality() != 0 {
+		t.Error("RemoveSet should be an empty set after removing 6 and 1")
+	}
+}
+
 func Test_RemoveUnsafeSet(t *testing.T) {
 	a := makeUnsafeSetInt([]int{6, 3, 1})
 
@@ -200,6 +220,26 @@ func Test_RemoveUnsafeSet(t *testing.T) {
 
 	a.Remove(6)
 	a.Remove(1)
+
+	if a.Cardinality() != 0 {
+		t.Error("RemoveSet should be an empty set after removing 6 and 1")
+	}
+}
+
+func Test_RemoveAllUnsafeSet(t *testing.T) {
+	a := makeUnsafeSetInt([]int{6, 3, 1, 8, 9})
+
+	a.RemoveAll(3, 1)
+
+	if a.Cardinality() != 3 {
+		t.Error("RemoveAll should only have 2 items in the set")
+	}
+
+	if !a.Contains(6, 8, 9) {
+		t.Error("RemoveAll should have only items (6,8,9) in the set")
+	}
+
+	a.RemoveAll(6, 8, 9)
 
 	if a.Cardinality() != 0 {
 		t.Error("RemoveSet should be an empty set after removing 6 and 1")

--- a/threadsafe.go
+++ b/threadsafe.go
@@ -38,6 +38,12 @@ func newThreadSafeSet[T comparable]() *threadSafeSet[T] {
 	}
 }
 
+func newThreadSafeSetWithSize[T comparable](cardinality int) *threadSafeSet[T] {
+	return &threadSafeSet[T]{
+		uss: newThreadUnsafeSetWithSize[T](cardinality),
+	}
+}
+
 func (t *threadSafeSet[T]) Add(v T) bool {
 	t.Lock()
 	ret := t.uss.Add(v)
@@ -152,6 +158,12 @@ func (t *threadSafeSet[T]) Clear() {
 func (t *threadSafeSet[T]) Remove(v T) {
 	t.Lock()
 	delete(t.uss, v)
+	t.Unlock()
+}
+
+func (t *threadSafeSet[T]) RemoveAll(i ...T) {
+	t.Lock()
+	t.uss.RemoveAll(i...)
 	t.Unlock()
 }
 

--- a/threadunsafe.go
+++ b/threadunsafe.go
@@ -41,6 +41,10 @@ func newThreadUnsafeSet[T comparable]() threadUnsafeSet[T] {
 	return make(threadUnsafeSet[T])
 }
 
+func newThreadUnsafeSetWithSize[T comparable](cardinality int) threadUnsafeSet[T] {
+	return make(threadUnsafeSet[T], cardinality)
+}
+
 func (s threadUnsafeSet[T]) Add(v T) bool {
 	prevLen := len(s)
 	s[v] = struct{}{}
@@ -74,7 +78,7 @@ func (s threadUnsafeSet[T]) Clear() {
 }
 
 func (s threadUnsafeSet[T]) Clone() Set[T] {
-	clonedSet := make(threadUnsafeSet[T], s.Cardinality())
+	clonedSet := newThreadUnsafeSetWithSize[T](s.Cardinality())
 	for elem := range s {
 		clonedSet.add(elem)
 	}
@@ -218,6 +222,12 @@ func (s threadUnsafeSet[T]) Pop() (v T, ok bool) {
 
 func (s threadUnsafeSet[T]) Remove(v T) {
 	delete(s, v)
+}
+
+func (s threadUnsafeSet[T]) RemoveAll(i ...T) {
+	for _, elem := range i {
+		delete(s, elem)
+	}
 }
 
 func (s threadUnsafeSet[T]) String() string {


### PR DESCRIPTION
This branch is largely dedicated to an issue that got proposed that I lost track of during the refactor to Generics. Performance gains can be had with the smarter use of capacity hint upon instantiation the sets.

- [Originally proposed](https://github.com/deckarep/golang-set/issues/60) by @fy0
- Utilize map capacity hint on `make` invocations  as an optimization upon instantiation of Sets
- Fixes some inconsistencies around doc comments
- Additionally adds a `RemoveAll` method

Any takers on CRing this? I'll leave it open for a few days and merge if nobody bites.

Cheers

-deckarep