### PR TITLE
fix: Deserialize using a generic approach.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+.idea

--- a/threadsafe_test.go
+++ b/threadsafe_test.go
@@ -540,7 +540,17 @@ func Test_UnmarshalJSON(t *testing.T) {
 		t.Errorf("Expected no difference, got: %v", expected.Difference(actual))
 	}
 }
-
+func TestThreadUnsafeSet_UnmarshalJSON(t *testing.T) {
+	expected := NewThreadUnsafeSet[int64](1, 2, 3)
+	actual := NewThreadUnsafeSet[int64]()
+	err := actual.UnmarshalJSON([]byte(`[1, 2, 3]`))
+	if err != nil {
+		t.Errorf("Error should be nil: %v", err)
+	}
+	if !expected.Equal(actual) {
+		t.Errorf("Expected no difference, got: %v", expected.Difference(actual))
+	}
+}
 func Test_MarshalJSON(t *testing.T) {
 	expected := NewSet(
 		[]string{

--- a/threadunsafe.go
+++ b/threadunsafe.go
@@ -26,7 +26,6 @@ SOFTWARE.
 package mapset
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -311,24 +310,12 @@ func (s threadUnsafeSet[T]) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON recreates a set from a JSON array, it only decodes
 // primitive types. Numbers are decoded as json.Number.
 func (s threadUnsafeSet[T]) UnmarshalJSON(b []byte) error {
-	var i []any
-
-	d := json.NewDecoder(bytes.NewReader(b))
-	d.UseNumber()
-	err := d.Decode(&i)
+	var i []T
+	err := json.Unmarshal(b, &i)
 	if err != nil {
 		return err
 	}
-
-	for _, v := range i {
-		switch t := v.(type) {
-		case T:
-			s.add(t)
-		default:
-			// anything else must be skipped.
-			continue
-		}
-	}
+	s.Append(i...)
 
 	return nil
 }


### PR DESCRIPTION
Deserialize using generics. The previous deserialization method had issues in generic scenarios.