### PR TITLE
Add is empty method

### DIFF
--- a/set.go
+++ b/set.go
@@ -97,6 +97,9 @@ type Set[T comparable] interface {
 	// panic.
 	Intersect(other Set[T]) Set[T]
 
+	// IsEmpty determines if there are elements in the set.
+	IsEmpty() bool
+
 	// IsProperSubset determines if every element in this set is in
 	// the other set but the two sets are not equal.
 	//

--- a/threadsafe.go
+++ b/threadsafe.go
@@ -74,6 +74,10 @@ func (t *threadSafeSet[T]) ContainsAny(v ...T) bool {
 	return ret
 }
 
+func (t *threadSafeSet[T]) IsEmpty() bool {
+	return t.Cardinality() == 0
+}
+
 func (t *threadSafeSet[T]) IsSubset(other Set[T]) bool {
 	o := other.(*threadSafeSet[T])
 

--- a/threadsafe_test.go
+++ b/threadsafe_test.go
@@ -259,6 +259,29 @@ func Test_IntersectConcurrent(t *testing.T) {
 	wg.Wait()
 }
 
+func Test_IsEmptyConcurrent(t *testing.T) {
+	runtime.GOMAXPROCS(2)
+
+	s := NewSet[int]()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		for i := 0; i < N; i++ {
+			size := s.Cardinality()
+			if s.IsEmpty() && size > 0 {
+				t.Errorf("Is Empty should be return false")
+			}
+		}
+		wg.Done()
+	}()
+
+	for i := 0; i < N; i++ {
+		s.Add(rand.Int())
+	}
+	wg.Wait()
+}
+
 func Test_IsSubsetConcurrent(t *testing.T) {
 	runtime.GOMAXPROCS(2)
 

--- a/threadunsafe.go
+++ b/threadunsafe.go
@@ -163,6 +163,10 @@ func (s threadUnsafeSet[T]) Intersect(other Set[T]) Set[T] {
 	return intersection
 }
 
+func (s threadUnsafeSet[T]) IsEmpty() bool {
+	return s.Cardinality() == 0
+}
+
 func (s threadUnsafeSet[T]) IsProperSubset(other Set[T]) bool {
 	return s.Cardinality() < other.Cardinality() && s.IsSubset(other)
 }


### PR DESCRIPTION
A useful way to verify is a set is empty. Instead of using `mySet.Cardinality() == 0`, we can use `mySet.IsEmpty()`. Is simplest, but improve readability. Another way that I think to do that was with a helper function, like `empty(mySet)`, but I tried to follow the current object-oriented approach.

This PR should close the issue #132 