### PR TITLE
Add 'Size() int' method

### DIFF
--- a/set.go
+++ b/set.go
@@ -166,6 +166,9 @@ type Set[T comparable] interface {
 	// RemoveAll removes multiple elements from the set.
 	RemoveAll(i ...T)
 
+	// Size of the set
+	Size() int
+
 	// String provides a convenient string representation
 	// of the current state of the set.
 	String() string

--- a/threadsafe.go
+++ b/threadsafe.go
@@ -272,6 +272,13 @@ func (t *threadSafeSet[T]) Clone() Set[T] {
 	return ret
 }
 
+func (t *threadSafeSet[T]) Size() int {
+	t.RLock()
+	ret := t.uss.Size()
+	t.RUnlock()
+	return ret
+}
+
 func (t *threadSafeSet[T]) String() string {
 	t.RLock()
 	ret := t.uss.String()

--- a/threadunsafe.go
+++ b/threadunsafe.go
@@ -269,6 +269,10 @@ func (s threadUnsafeSet[T]) RemoveAll(i ...T) {
 	}
 }
 
+func (s threadUnsafeSet[T]) Size() int {
+	return len(s)
+}
+
 func (s threadUnsafeSet[T]) String() string {
 	items := make([]string, 0, len(s))
 

--- a/threadunsafe_test.go
+++ b/threadunsafe_test.go
@@ -65,6 +65,28 @@ func TestThreadUnsafeSet_MarshalJSON(t *testing.T) {
 	}
 }
 
+func TestThreadUnsageSet_Size(t *testing.T) {
+	set := newThreadSafeSet[string]()
+	var expected int
+	if got := set.Size(); got != expected {
+		t.Fatalf("expected size of %d, got %d", expected, got)
+	}
+	set.Add("hello")
+	expected++
+	if got := set.Size(); got != expected {
+		t.Fatalf("expected size of %d, got %d", expected, got)
+	}
+	set.Add("hello")
+	if got := set.Size(); got != expected {
+		t.Fatalf("expected size of %d, got %d", expected, got)
+	}
+	set.Add("there")
+	expected++
+	if got := set.Size(); got != expected {
+		t.Fatalf("expected size of %d, got %d", expected, got)
+	}
+}
+
 func TestThreadUnsafeSet_UnmarshalJSON(t *testing.T) {
 	expected := NewThreadUnsafeSet[int64](1, 2, 3)
 	actual := NewThreadUnsafeSet[int64]()
@@ -107,6 +129,7 @@ func TestThreadUnsafeSet_MarshalJSON_Struct(t *testing.T) {
 		t.Errorf("Expected no difference, got: %v", expected.Set.Difference(actual.Set))
 	}
 }
+
 func TestThreadUnsafeSet_UnmarshalJSON_Struct(t *testing.T) {
 	expected := &testStruct{"test", NewThreadUnsafeSet("a", "b", "c")}
 	actual := &testStruct{}


### PR DESCRIPTION
There are a bunch of times I need to find the size of the set and having to convert to a slice or use an iterator is a pita.