### PR TITLE
Deadlock: if the callback on Each panics and the app has a recovery - issue 163

### DIFF
--- a/threadsafe.go
+++ b/threadsafe.go
@@ -208,12 +208,12 @@ func (t *threadSafeSet[T]) Cardinality() int {
 
 func (t *threadSafeSet[T]) Each(cb func(T) bool) {
 	t.RLock()
+	defer t.RUnlock()
 	for elem := range *t.uss {
 		if cb(elem) {
 			break
 		}
 	}
-	t.RUnlock()
 }
 
 func (t *threadSafeSet[T]) Iter() <-chan T {
@@ -286,8 +286,9 @@ func (t *threadSafeSet[T]) Pop() (T, bool) {
 }
 
 func (t *threadSafeSet[T]) ToSlice() []T {
-	keys := make([]T, 0, t.Cardinality())
 	t.RLock()
+	l := len(*t.uss)
+	keys := make([]T, 0, l)
 	for elem := range *t.uss {
 		keys = append(keys, elem)
 	}

--- a/threadsafe_test.go
+++ b/threadsafe_test.go
@@ -652,14 +652,13 @@ func Test_DeadlockOnEachCallbackWhenPanic(t *testing.T) {
 		defer func() {
 			if r := recover(); r != nil {
 				panicOccured = true
-				err = fmt.Errorf("failed to print IDs: panicked: %v", r)
+				err = fmt.Errorf("failed to do work: %v", r)
 			}
 		}()
 
 		s.Each(func(n *int) bool {
 			// NOTE: this will throw a panic once we get to the nil element.
-			result := *n * 2
-			fmt.Println("result is dereferenced doubled:", result)
+			_ = *n * 2
 			return false
 		})
 


### PR DESCRIPTION
- Ensures the read lock is still unlocked if a panic occurs within the callback of the `Each` function and a recovery handler runs.
- Fixes the capacity hint in ToSlice by ensuring the Cardinality is read under the confines of the read lock.
- Adds a unit test