### PR TITLE
Added match() function based on boolean predicate func

### DIFF
--- a/set.go
+++ b/set.go
@@ -161,6 +161,10 @@ type Set[T comparable] interface {
 	// Iterator returns an Iterator object that you can
 	// use to range over the set.
 	Iterator() *Iterator[T]
+	
+	// MatchesFunc() returns whether at least one element in the set
+	// matches the provided predicate function.
+	MatchesFunc(func(T) bool) bool
 
 	// Remove removes a single element from the set.
 	Remove(i T)

--- a/threadsafe.go
+++ b/threadsafe.go
@@ -62,6 +62,14 @@ func (t *threadSafeSet[T]) Append(v ...T) int {
 	return ret
 }
 
+func (t *threadSafeSet[T]) MatchesFunc(predicate func(T) bool) bool {
+	t.RLock()
+	ret := t.uss.MatchesFunc(predicate)
+	t.RUnlock()
+	
+	return ret
+}
+
 func (t *threadSafeSet[T]) Contains(v ...T) bool {
 	t.RLock()
 	ret := t.uss.Contains(v...)

--- a/threadunsafe.go
+++ b/threadunsafe.go
@@ -89,6 +89,15 @@ func (s *threadUnsafeSet[T]) Clone() Set[T] {
 	return clonedSet
 }
 
+func (s *threadUnsafeSet[T]) MatchesFunc(predicate func(T) bool) bool {
+	for elem := range *s {
+		if predicate(elem) {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *threadUnsafeSet[T]) Contains(v ...T) bool {
 	for _, val := range v {
 		if _, ok := (*s)[val]; !ok {


### PR DESCRIPTION
Addressing the following issue - https://github.com/deckarep/golang-set/issues/167
Added this simple implementation of the match() method based on a boolean predicate func() parameter.