### PR TITLE
Replace unused return values from `Add()` calls with `add()` and optimize loop traversal

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -38,6 +38,22 @@ func nrand(n int) []int {
 	return i
 }
 
+func BenchmarkNewSet(b *testing.B) {
+	nums := nrand(1000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = NewSet(nums...)
+	}
+}
+
+func BenchmarkNewThreadUnsafeSet(b *testing.B) {
+	nums := nrand(1000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = NewThreadUnsafeSet(nums...)
+	}
+}
+
 func benchAdd(b *testing.B, n int, newSet func(...int) Set[int]) {
 	nums := nrand(n)
 	b.ResetTimer()
@@ -55,6 +71,23 @@ func BenchmarkAddSafe(b *testing.B) {
 
 func BenchmarkAddUnsafe(b *testing.B) {
 	benchAdd(b, 1000, NewThreadUnsafeSet[int])
+}
+
+func benchAppend(b *testing.B, n int, newSet func(...int) Set[int]) {
+	nums := nrand(n)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s := newSet()
+		s.Append(nums...)
+	}
+}
+
+func BenchmarkAppendSafe(b *testing.B) {
+	benchAppend(b, 1000, NewSet[int])
+}
+
+func BenchmarkAppendUnsafe(b *testing.B) {
+	benchAppend(b, 1000, NewThreadUnsafeSet[int])
 }
 
 func benchRemove(b *testing.B, s Set[int]) {

--- a/set.go
+++ b/set.go
@@ -235,9 +235,7 @@ func NewSetWithSize[T comparable](cardinality int) Set[T] {
 // Operations on the resulting set are not thread-safe.
 func NewThreadUnsafeSet[T comparable](vs ...T) Set[T] {
 	s := newThreadUnsafeSetWithSize[T](len(vs))
-	for i := range vs {
-		s.add(vs[i])
-	}
+	s.append(vs...)
 	return s
 }
 

--- a/set.go
+++ b/set.go
@@ -219,9 +219,7 @@ type Set[T comparable] interface {
 // Operations on the resulting set are thread-safe.
 func NewSet[T comparable](vs ...T) Set[T] {
 	s := newThreadSafeSetWithSize[T](len(vs))
-	for i := range vs {
-		s.Add(vs[i])
-	}
+	s.uss.append(vs...)
 	return s
 }
 
@@ -248,10 +246,10 @@ func NewThreadUnsafeSetWithSize[T comparable](cardinality int) Set[T] {
 // NewSetFromMapKeys creates and returns a new set with the given keys of the map.
 // Operations on the resulting set are thread-safe.
 func NewSetFromMapKeys[T comparable, V any](val map[T]V) Set[T] {
-	s := NewSetWithSize[T](len(val))
+	s := newThreadSafeSetWithSize[T](len(val))
 
 	for k := range val {
-		s.Add(k)
+		s.uss.add(k)
 	}
 
 	return s

--- a/set.go
+++ b/set.go
@@ -217,10 +217,10 @@ type Set[T comparable] interface {
 
 // NewSet creates and returns a new set with the given elements.
 // Operations on the resulting set are thread-safe.
-func NewSet[T comparable](vals ...T) Set[T] {
-	s := newThreadSafeSetWithSize[T](len(vals))
-	for _, item := range vals {
-		s.Add(item)
+func NewSet[T comparable](vs ...T) Set[T] {
+	s := newThreadSafeSetWithSize[T](len(vs))
+	for i := range vs {
+		s.Add(vs[i])
 	}
 	return s
 }
@@ -228,16 +228,15 @@ func NewSet[T comparable](vals ...T) Set[T] {
 // NewSetWithSize creates and returns a reference to an empty set with a specified
 // capacity. Operations on the resulting set are thread-safe.
 func NewSetWithSize[T comparable](cardinality int) Set[T] {
-	s := newThreadSafeSetWithSize[T](cardinality)
-	return s
+	return newThreadSafeSetWithSize[T](cardinality)
 }
 
 // NewThreadUnsafeSet creates and returns a new set with the given elements.
 // Operations on the resulting set are not thread-safe.
-func NewThreadUnsafeSet[T comparable](vals ...T) Set[T] {
-	s := newThreadUnsafeSetWithSize[T](len(vals))
-	for _, item := range vals {
-		s.Add(item)
+func NewThreadUnsafeSet[T comparable](vs ...T) Set[T] {
+	s := newThreadUnsafeSetWithSize[T](len(vs))
+	for i := range vs {
+		s.add(vs[i])
 	}
 	return s
 }
@@ -245,8 +244,7 @@ func NewThreadUnsafeSet[T comparable](vals ...T) Set[T] {
 // NewThreadUnsafeSetWithSize creates and returns a reference to an empty set with
 // a specified capacity. Operations on the resulting set are not thread-safe.
 func NewThreadUnsafeSetWithSize[T comparable](cardinality int) Set[T] {
-	s := newThreadUnsafeSetWithSize[T](cardinality)
-	return s
+	return newThreadUnsafeSetWithSize[T](cardinality)
 }
 
 // NewSetFromMapKeys creates and returns a new set with the given keys of the map.
@@ -264,10 +262,10 @@ func NewSetFromMapKeys[T comparable, V any](val map[T]V) Set[T] {
 // NewThreadUnsafeSetFromMapKeys creates and returns a new set with the given keys of the map.
 // Operations on the resulting set are not thread-safe.
 func NewThreadUnsafeSetFromMapKeys[T comparable, V any](val map[T]V) Set[T] {
-	s := NewThreadUnsafeSetWithSize[T](len(val))
+	s := newThreadUnsafeSetWithSize[T](len(val))
 
 	for k := range val {
-		s.Add(k)
+		s.add(k)
 	}
 
 	return s

--- a/threadunsafe.go
+++ b/threadunsafe.go
@@ -55,17 +55,22 @@ func (s *threadUnsafeSet[T]) Add(v T) bool {
 	return prevLen != s.Cardinality()
 }
 
-func (s *threadUnsafeSet[T]) Append(vs ...T) int {
-	prevLen := s.Cardinality()
-	for i := range vs {
-		s.add(vs[i])
-	}
-	return s.Cardinality() - prevLen
-}
-
 // private version of Add which doesn't return a value
 func (s *threadUnsafeSet[T]) add(v T) {
 	(*s)[v] = struct{}{}
+}
+
+func (s *threadUnsafeSet[T]) Append(vs ...T) int {
+	prevLen := s.Cardinality()
+	s.append(vs...)
+	return s.Cardinality() - prevLen
+}
+
+// private version of Append which doesn't return a value
+func (s *threadUnsafeSet[T]) append(vs ...T) {
+	for i := range vs {
+		s.add(vs[i])
+	}
 }
 
 func (s *threadUnsafeSet[T]) Cardinality() int {
@@ -83,15 +88,15 @@ func (s *threadUnsafeSet[T]) Clear() {
 
 func (s *threadUnsafeSet[T]) Clone() Set[T] {
 	clonedSet := newThreadUnsafeSetWithSize[T](s.Cardinality())
-	for elem := range *s {
-		clonedSet.add(elem)
+	for v := range *s {
+		clonedSet.add(v)
 	}
 	return clonedSet
 }
 
-func (s *threadUnsafeSet[T]) Contains(v ...T) bool {
-	for _, val := range v {
-		if _, ok := (*s)[val]; !ok {
+func (s *threadUnsafeSet[T]) Contains(vs ...T) bool {
+	for _, v := range vs {
+		if !s.contains(v) {
 			return false
 		}
 	}
@@ -99,13 +104,12 @@ func (s *threadUnsafeSet[T]) Contains(v ...T) bool {
 }
 
 func (s *threadUnsafeSet[T]) ContainsOne(v T) bool {
-	_, ok := (*s)[v]
-	return ok
+	return s.contains(v)
 }
 
-func (s *threadUnsafeSet[T]) ContainsAny(v ...T) bool {
-	for _, val := range v {
-		if _, ok := (*s)[val]; ok {
+func (s *threadUnsafeSet[T]) ContainsAny(vs ...T) bool {
+	for _, v := range vs {
+		if s.contains(v) {
 			return true
 		}
 	}
@@ -289,8 +293,8 @@ func (s threadUnsafeSet[T]) Remove(v T) {
 	delete(s, v)
 }
 
-func (s threadUnsafeSet[T]) RemoveAll(i ...T) {
-	for _, elem := range i {
+func (s threadUnsafeSet[T]) RemoveAll(vs ...T) {
+	for _, elem := range vs {
 		delete(s, elem)
 	}
 }
@@ -372,9 +376,7 @@ func (s *threadUnsafeSet[T]) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	for i := range is {
-		s.add(is[i])
-	}
+	s.append(is...)
 	return nil
 }
 
@@ -394,8 +396,6 @@ func (s *threadUnsafeSet[T]) UnmarshalBSONValue(bt bsontype.Type, b []byte) erro
 		return err
 	}
 
-	for i := range is {
-		s.add(is[i])
-	}
+	s.append(is...)
 	return nil
 }

--- a/threadunsafe.go
+++ b/threadunsafe.go
@@ -88,15 +88,15 @@ func (s *threadUnsafeSet[T]) Clear() {
 
 func (s *threadUnsafeSet[T]) Clone() Set[T] {
 	clonedSet := newThreadUnsafeSetWithSize[T](s.Cardinality())
-	for v := range *s {
-		clonedSet.add(v)
+	for elem := range *s {
+		clonedSet.add(elem)
 	}
 	return clonedSet
 }
 
-func (s *threadUnsafeSet[T]) Contains(vs ...T) bool {
-	for _, v := range vs {
-		if !s.contains(v) {
+func (s *threadUnsafeSet[T]) Contains(v ...T) bool {
+	for _, val := range v {
+		if !s.contains(val) {
 			return false
 		}
 	}
@@ -107,9 +107,9 @@ func (s *threadUnsafeSet[T]) ContainsOne(v T) bool {
 	return s.contains(v)
 }
 
-func (s *threadUnsafeSet[T]) ContainsAny(vs ...T) bool {
-	for _, v := range vs {
-		if s.contains(v) {
+func (s *threadUnsafeSet[T]) ContainsAny(v ...T) bool {
+	for _, val := range v {
+		if s.contains(val) {
 			return true
 		}
 	}
@@ -138,8 +138,8 @@ func (s *threadUnsafeSet[T]) ContainsAnyElement(other Set[T]) bool {
 
 // private version of Contains for a single element v
 func (s *threadUnsafeSet[T]) contains(v T) (ok bool) {
-	_, ok = (*s)[v]
-	return ok
+	_, found := (*s)[v]
+	return found
 }
 
 func (s *threadUnsafeSet[T]) Difference(other Set[T]) Set[T] {
@@ -293,8 +293,8 @@ func (s threadUnsafeSet[T]) Remove(v T) {
 	delete(s, v)
 }
 
-func (s threadUnsafeSet[T]) RemoveAll(vs ...T) {
-	for _, elem := range vs {
+func (s threadUnsafeSet[T]) RemoveAll(i ...T) {
+	for _, elem := range i {
 		delete(s, elem)
 	}
 }
@@ -371,12 +371,13 @@ func (s threadUnsafeSet[T]) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON recreates a set from a JSON array, it only decodes
 // primitive types. Numbers are decoded as json.Number.
 func (s *threadUnsafeSet[T]) UnmarshalJSON(b []byte) error {
-	var is []T
-	if err := json.Unmarshal(b, &is); err != nil {
+	var i []T
+	err := json.Unmarshal(b, &i)
+	if err != nil {
 		return err
 	}
+	s.append(i...)
 
-	s.append(is...)
 	return nil
 }
 
@@ -386,16 +387,17 @@ func (s threadUnsafeSet[T]) MarshalBSONValue() (bsontype.Type, []byte, error) {
 }
 
 // UnmarshalBSON recreates a set from a BSON array.
-func (s *threadUnsafeSet[T]) UnmarshalBSONValue(bt bsontype.Type, b []byte) error {
+func (s threadUnsafeSet[T]) UnmarshalBSONValue(bt bsontype.Type, b []byte) error {
 	if bt != bson.TypeArray {
 		return fmt.Errorf("must use BSON Array to unmarshal Set")
 	}
 
-	var is []T
-	if err := bson.UnmarshalValue(bt, b, &is); err != nil {
+	var i []T
+	err := bson.UnmarshalValue(bt, b, &i)
+	if err != nil {
 		return err
 	}
+	s.append(i...)
 
-	s.append(is...)
 	return nil
 }

--- a/threadunsafe.go
+++ b/threadunsafe.go
@@ -49,18 +49,18 @@ func newThreadUnsafeSetWithSize[T comparable](cardinality int) *threadUnsafeSet[
 	return &t
 }
 
-func (s threadUnsafeSet[T]) Add(v T) bool {
-	prevLen := len(s)
-	s[v] = struct{}{}
-	return prevLen != len(s)
+func (s *threadUnsafeSet[T]) Add(v T) bool {
+	prevLen := s.Cardinality()
+	s.add(v)
+	return prevLen != s.Cardinality()
 }
 
-func (s *threadUnsafeSet[T]) Append(v ...T) int {
-	prevLen := len(*s)
-	for _, val := range v {
-		(*s)[val] = struct{}{}
+func (s *threadUnsafeSet[T]) Append(vs ...T) int {
+	prevLen := s.Cardinality()
+	for i := range vs {
+		s.add(vs[i])
 	}
-	return len(*s) - prevLen
+	return s.Cardinality() - prevLen
 }
 
 // private version of Add which doesn't return a value
@@ -365,13 +365,14 @@ func (s threadUnsafeSet[T]) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON recreates a set from a JSON array, it only decodes
 // primitive types. Numbers are decoded as json.Number.
 func (s *threadUnsafeSet[T]) UnmarshalJSON(b []byte) error {
-	var i []T
-	err := json.Unmarshal(b, &i)
-	if err != nil {
+	var is []T
+	if err := json.Unmarshal(b, &is); err != nil {
 		return err
 	}
-	s.Append(i...)
 
+	for i := range is {
+		s.add(is[i])
+	}
 	return nil
 }
 
@@ -381,17 +382,18 @@ func (s threadUnsafeSet[T]) MarshalBSONValue() (bsontype.Type, []byte, error) {
 }
 
 // UnmarshalBSON recreates a set from a BSON array.
-func (s threadUnsafeSet[T]) UnmarshalBSONValue(bt bsontype.Type, b []byte) error {
+func (s *threadUnsafeSet[T]) UnmarshalBSONValue(bt bsontype.Type, b []byte) error {
 	if bt != bson.TypeArray {
 		return fmt.Errorf("must use BSON Array to unmarshal Set")
 	}
 
-	var i []T
-	err := bson.UnmarshalValue(bt, b, &i)
-	if err != nil {
+	var is []T
+	if err := bson.UnmarshalValue(bt, b, &is); err != nil {
 		return err
 	}
-	s.Append(i...)
 
+	for i := range is {
+		s.add(is[i])
+	}
 	return nil
 }


### PR DESCRIPTION
### Key Changes

This pull request makes two main performance optimizations:

#### 1. **Replace `Add()` with `add()` when return values are not used**

When the boolean return value from `Add()` is not needed, the code now calls the private `add()` method instead. This eliminates unnecessary `len()` calls:

- **Example from `NewThreadUnsafeSet()`:**
  ```go
  // Before: Uses public Add() method that checks length
  for _, item := range vals {
      s.Add(item)  // Returns bool, but value is discarded
  }
  
  // After: Uses private add() method without length check
  for i := range vs {
      s.add(vs[i])  // No unnecessary len() overhead
  }
  ```

#### 2. **Replace value-based slice iteration with index-based loops**

Instead of using `for _, val := range slice`, the code now uses `for i := range slice` to access elements by index:

- **Example from `Append()`:**
  ```go
  // Before: Range iteration with values
  for _, val := range v {
      (*s)[val] = struct{}{}
  }
  
  // After: Index-based iteration
  for i := range vs {
      s.add(vs[i])
  }
  ```

### Files Modified

1. **`bench_test.go`** - Added benchmarks for `NewSet()`, `NewThreadUnsafeSet()`, `Append()`, and other methods
2. **`set.go`** - Optimized `NewSet()`, `NewThreadUnsafeSet()`, and related functions to use `add()` method
3. **`threadunsafe.go`** - Updated `Add()`, `Append()`, and unmarshal methods to use index-based iteration and private `add()` calls

### Additional Improvements

- Parameter name changes for clarity: `vals` → `vs`, `item` → (index-based), `i` → `is` (for slices)
- Simplified returns by eliminating intermediate variables
- Changed receiver types from value to pointer for consistency in `Add()` and unmarshal methods

### Benchmark
#### Before
```
BenchmarkNewSet-10                          	   87181	     13777 ns/op	   37032 B/op	       8 allocs/op
BenchmarkNewThreadUnsafeSet-10              	  149496	      8105 ns/op	   36944 B/op	       5 allocs/op
BenchmarkAddSafe-10                         	   30235	     38487 ns/op	   74496 B/op	      24 allocs/op
BenchmarkAddUnsafe-10                       	   33435	     36432 ns/op	   74464 B/op	      23 allocs/op
BenchmarkAppendSafe-10                      	   34560	     35259 ns/op	   74496 B/op	      24 allocs/op
BenchmarkAppendUnsafe-10                    	   33500	     36150 ns/op	   74464 B/op	      23 allocs/op
```

#### After
```
BenchmarkNewSet-10                          	  158842	      7448 ns/op	   36944 B/op	       5 allocs/op
BenchmarkNewThreadUnsafeSet-10              	  158649	      7544 ns/op	   36944 B/op	       5 allocs/op
BenchmarkAddSafe-10                         	   33783	     35403 ns/op	   74496 B/op	      24 allocs/op
BenchmarkAddUnsafe-10                       	   37732	     31670 ns/op	   74464 B/op	      23 allocs/op
BenchmarkAppendSafe-10                      	   38198	     31662 ns/op	   74496 B/op	      24 allocs/op
BenchmarkAppendUnsafe-10                    	   38355	     31581 ns/op	   74464 B/op	      23 allocs/op
```