### PR TITLE
Specify Map Capacity for Sets

### DIFF
--- a/threadunsafe.go
+++ b/threadunsafe.go
@@ -141,13 +141,13 @@ func (s *threadUnsafeSet[T]) contains(v T) (ok bool) {
 func (s *threadUnsafeSet[T]) Difference(other Set[T]) Set[T] {
 	o := other.(*threadUnsafeSet[T])
 
-	diff := newThreadUnsafeSet[T]()
+	diff := make(threadUnsafeSet[T], s.Cardinality())
 	for elem := range *s {
 		if !o.contains(elem) {
 			diff.add(elem)
 		}
 	}
-	return diff
+	return &diff
 }
 
 func (s *threadUnsafeSet[T]) Each(cb func(T) bool) {
@@ -175,22 +175,24 @@ func (s *threadUnsafeSet[T]) Equal(other Set[T]) bool {
 func (s *threadUnsafeSet[T]) Intersect(other Set[T]) Set[T] {
 	o := other.(*threadUnsafeSet[T])
 
-	intersection := newThreadUnsafeSet[T]()
+	var intersection threadUnsafeSet[T]
 	// loop over smaller set
 	if s.Cardinality() < other.Cardinality() {
+		intersection = make(threadUnsafeSet[T], s.Cardinality())
 		for elem := range *s {
 			if o.contains(elem) {
 				intersection.add(elem)
 			}
 		}
 	} else {
+		intersection = make(threadUnsafeSet[T], o.Cardinality())
 		for elem := range *o {
 			if s.contains(elem) {
 				intersection.add(elem)
 			}
 		}
 	}
-	return intersection
+	return &intersection
 }
 
 func (s *threadUnsafeSet[T]) IsEmpty() bool {
@@ -305,7 +307,9 @@ func (s threadUnsafeSet[T]) String() string {
 func (s *threadUnsafeSet[T]) SymmetricDifference(other Set[T]) Set[T] {
 	o := other.(*threadUnsafeSet[T])
 
-	sd := newThreadUnsafeSet[T]()
+	// maximum number of elements is the sum of s and o cardinalities (when s and o are disjoint)
+	n := s.Cardinality() + o.Cardinality()
+	sd := make(threadUnsafeSet[T], n)
 	for elem := range *s {
 		if !o.contains(elem) {
 			sd.add(elem)
@@ -316,7 +320,7 @@ func (s *threadUnsafeSet[T]) SymmetricDifference(other Set[T]) Set[T] {
 			sd.add(elem)
 		}
 	}
-	return sd
+	return &sd
 }
 
 func (s threadUnsafeSet[T]) ToSlice() []T {
@@ -331,10 +335,8 @@ func (s threadUnsafeSet[T]) ToSlice() []T {
 func (s threadUnsafeSet[T]) Union(other Set[T]) Set[T] {
 	o := other.(*threadUnsafeSet[T])
 
-	n := s.Cardinality()
-	if o.Cardinality() > n {
-		n = o.Cardinality()
-	}
+	// maximum number of elements is the sum of s and o cardinalities (when s and o are disjoint)
+	n := s.Cardinality() + o.Cardinality()
 	unionedSet := make(threadUnsafeSet[T], n)
 
 	for elem := range s {


### PR DESCRIPTION
### Context
Pre-allocating map capacity improves performance for sets that will quickly contain a large number of items by reducing internal map allocations and rehashes during growth.

### Proposal
Allow users to specify the capacity of the underlying map when creating a set through new functions or constructor parameters.

### Expected Benefits
- **Reduced allocations**: Avoid repeated memory allocations as the map grows
- **Better performance**: Fewer internal rehashes when the set grows to large sizes
- **Predictable memory**: Users can pre-allocate based on known requirements

### Suggested Implementation Areas
- `Union()`, `Difference()`, `Intersection()` and other set operations
- Constructor functions like `NewSet()` and `NewThreadUnsafeSet()`

## Benchmark
### Before:
```
BenchmarkDifference1Safe-10                            	 8686674	       133.5 ns/op	     232 B/op	       4 allocs/op
BenchmarkDifference1Unsafe-10                          	 8223676	       121.6 ns/op	     200 B/op	       3 allocs/op
BenchmarkDifference10Safe-10                           	 5388849	       269.2 ns/op	     232 B/op	       4 allocs/op
BenchmarkDifference10Unsafe-10                         	 5696812	       212.2 ns/op	     200 B/op	       3 allocs/op
BenchmarkDifference100Safe-10                          	  455571	      3238 ns/op	    2352 B/op	      11 allocs/op
BenchmarkDifference100Unsafe-10                        	  478160	      2801 ns/op	    2320 B/op	      10 allocs/op
BenchmarkIntersect1Safe-10                             	 7853306	       153.1 ns/op	     232 B/op	       4 allocs/op
BenchmarkIntersect1Unsafe-10                           	10419315	       140.4 ns/op	     200 B/op	       3 allocs/op
BenchmarkIntersect10Safe-10                            	 4871457	       290.7 ns/op	     232 B/op	       4 allocs/op
BenchmarkIntersect10Unsafe-10                          	 5163304	       238.9 ns/op	     200 B/op	       3 allocs/op
BenchmarkIntersect100Safe-10                           	  356539	      3335 ns/op	    2352 B/op	      11 allocs/op
BenchmarkIntersect100Unsafe-10                         	  367843	      2738 ns/op	    2320 B/op	      10 allocs/op
BenchmarkSymmetricDifference1Safe-10                   	 9256645	       119.8 ns/op	      88 B/op	       3 allocs/op
BenchmarkSymmetricDifference1Unsafe-10                 	11290568	        99.62 ns/op	      56 B/op	       2 allocs/op
BenchmarkSymmetricDifference10Safe-10                  	 1757301	       618.1 ns/op	     560 B/op	       7 allocs/op
BenchmarkSymmetricDifference10Unsafe-10                	 1839495	       610.1 ns/op	     528 B/op	       6 allocs/op
BenchmarkSymmetricDifference100Safe-10                 	  230982	      6177 ns/op	    4688 B/op	      13 allocs/op
BenchmarkSymmetricDifference100Unsafe-10               	  224268	      5461 ns/op	    4656 B/op	      12 allocs/op
BenchmarkUnion1Safe-10                                 	 8942240	       156.5 ns/op	     232 B/op	       4 allocs/op
BenchmarkUnion1Unsafe-10                               	 9247514	       131.6 ns/op	     200 B/op	       3 allocs/op
BenchmarkUnion10Safe-10                                	 2349142	       461.2 ns/op	     560 B/op	       7 allocs/op
BenchmarkUnion10Unsafe-10                              	 2994007	       489.7 ns/op	     528 B/op	       6 allocs/op
BenchmarkUnion100Safe-10                               	  413222	      3145 ns/op	    3616 B/op	       8 allocs/op
BenchmarkUnion100Unsafe-10                             	  368803	      3639 ns/op	    3584 B/op	       7 allocs/op
```

### After
```
BenchmarkDifference1Safe-10                            	11882152	        99.51 ns/op	     232 B/op	       4 allocs/op
BenchmarkDifference1Unsafe-10                          	15047430	        80.35 ns/op	     200 B/op	       3 allocs/op
BenchmarkDifference10Safe-10                           	 5473782	       213.0 ns/op	     416 B/op	       6 allocs/op
BenchmarkDifference10Unsafe-10                         	 5974866	       203.0 ns/op	     384 B/op	       5 allocs/op
BenchmarkDifference100Safe-10                          	  809781	      1398 ns/op	    2432 B/op	       6 allocs/op
BenchmarkDifference100Unsafe-10                        	  846268	      1378 ns/op	    2400 B/op	       5 allocs/op
BenchmarkIntersect1Safe-10                             	11855847	        97.75 ns/op	     232 B/op	       4 allocs/op
BenchmarkIntersect1Unsafe-10                           	14541568	        81.98 ns/op	     200 B/op	       3 allocs/op
BenchmarkIntersect10Safe-10                            	 4795905	       274.2 ns/op	     416 B/op	       6 allocs/op
BenchmarkIntersect10Unsafe-10                          	 4552374	       230.8 ns/op	     384 B/op	       5 allocs/op
BenchmarkIntersect100Safe-10                           	  781599	      1500 ns/op	    2432 B/op	       6 allocs/op
BenchmarkIntersect100Unsafe-10                         	  789537	      1479 ns/op	    2400 B/op	       5 allocs/op
BenchmarkSymmetricDifference1Safe-10                   	13241330	        93.64 ns/op	      88 B/op	       3 allocs/op
BenchmarkSymmetricDifference1Unsafe-10                 	15871274	        75.52 ns/op	      56 B/op	       2 allocs/op
BenchmarkSymmetricDifference10Safe-10                  	 2893167	       410.3 ns/op	     704 B/op	       6 allocs/op
BenchmarkSymmetricDifference10Unsafe-10                	 2990696	       398.7 ns/op	     672 B/op	       5 allocs/op
BenchmarkSymmetricDifference100Safe-10                 	  431455	      2796 ns/op	    4992 B/op	       6 allocs/op
BenchmarkSymmetricDifference100Unsafe-10               	  408003	      2788 ns/op	    4960 B/op	       5 allocs/op
BenchmarkUnion1Safe-10                                 	12074301	       102.5 ns/op	     232 B/op	       4 allocs/op
BenchmarkUnion1Unsafe-10                               	12250747	        84.23 ns/op	     200 B/op	       3 allocs/op
BenchmarkUnion10Safe-10                                	 5075158	       250.7 ns/op	     416 B/op	       6 allocs/op
BenchmarkUnion10Unsafe-10                              	 5286973	       230.0 ns/op	     384 B/op	       5 allocs/op
BenchmarkUnion100Safe-10                               	  697135	      1652 ns/op	    2432 B/op	       6 allocs/op
BenchmarkUnion100Unsafe-10                             	  741138	      1642 ns/op	    2400 B/op	       5 allocs/op
```