### PR TITLE
Add Filter method for flexible set element filtering

### DIFF
--- a/set.go
+++ b/set.go
@@ -154,6 +154,10 @@ type Set[T comparable] interface {
 	// If passed func returns true, stop iteration at the time.
 	Each(func(T) bool)
 
+	// Filter iterates over elements and executes the passed func against each element.
+	// If passed func returns true, the element will be added to the returned set.
+	Filter(func(T) bool) Set[T]
+
 	// Iter returns a channel of elements that you can
 	// range over.
 	Iter() <-chan T

--- a/set_test.go
+++ b/set_test.go
@@ -1081,6 +1081,100 @@ func Test_Each(t *testing.T) {
 	}
 }
 
+func Test_Filter(t *testing.T) {
+	a := NewSet[string]()
+	a.Add("Z")
+	a.Add("Y")
+	a.Add("X")
+	a.Add("W")
+
+	// Returning true keeps the element; returning false drops it.
+	keepFromX := a.Filter(func(elem string) bool {
+		return elem >= "X"
+	})
+
+	expected := NewSet("Z", "Y", "X")
+	if !keepFromX.Equal(expected) {
+		t.Errorf("Expected %v, got %v", expected, keepFromX)
+	}
+
+	// Source set must be unmodified.
+	if a.Cardinality() != 4 {
+		t.Errorf("Expected source cardinality 4, got %d", a.Cardinality())
+	}
+
+	// Returning true for all elements should clone the set.
+	all := a.Filter(func(string) bool { return true })
+	if !all.Equal(a) {
+		t.Errorf("Expected clone of source, got %v", all)
+	}
+	if all == a {
+		t.Error("Expected Filter to return a new Set, not the same reference")
+	}
+
+	// Returning false for all elements should yield an empty set.
+	none := a.Filter(func(string) bool { return false })
+	if none.Cardinality() != 0 {
+		t.Errorf("Expected empty set, got %v", none)
+	}
+
+	// Filter on an empty set returns an empty set.
+	empty := NewSet[string]()
+	emptyOut := empty.Filter(func(string) bool { return true })
+	if emptyOut.Cardinality() != 0 {
+		t.Errorf("Expected empty set from empty source, got %v", emptyOut)
+	}
+}
+
+func Test_UnsafeFilter(t *testing.T) {
+	a := NewThreadUnsafeSet[int]()
+	a.Add(1)
+	a.Add(2)
+	a.Add(3)
+	a.Add(4)
+
+	evens := a.Filter(func(elem int) bool {
+		return elem%2 == 0
+	})
+
+	expected := NewThreadUnsafeSet(2, 4)
+	if !evens.Equal(expected) {
+		t.Errorf("Expected %v, got %v", expected, evens)
+	}
+
+	// Source set must be unmodified.
+	if a.Cardinality() != 4 {
+		t.Errorf("Expected source cardinality 4, got %d", a.Cardinality())
+	}
+
+	// Drop everything.
+	none := a.Filter(func(int) bool { return false })
+	if none.Cardinality() != 0 {
+		t.Errorf("Expected empty set, got %v", none)
+	}
+
+	// Empty source.
+	empty := NewThreadUnsafeSet[int]()
+	emptyOut := empty.Filter(func(int) bool { return true })
+	if emptyOut.Cardinality() != 0 {
+		t.Errorf("Expected empty set from empty source, got %v", emptyOut)
+	}
+}
+
+func Test_FilterVisitsAllElements(t *testing.T) {
+	a := NewSet(1, 2, 3, 4, 5)
+
+	visited := NewSet[int]()
+	a.Filter(func(elem int) bool {
+		visited.Add(elem)
+		return false
+	})
+
+	if !visited.Equal(a) {
+		t.Errorf("Filter did not visit every element: visited %v, expected %v", visited, a)
+	}
+}
+
 func Test_Iter(t *testing.T) {
 	a := NewSet[string]()
 

--- a/threadsafe.go
+++ b/threadsafe.go
@@ -220,6 +220,18 @@ func (t *threadSafeSet[T]) Each(cb func(T) bool) {
 	}
 }
 
+func (t *threadSafeSet[T]) Filter(cb func(T) bool) Set[T] {
+	t.RLock()
+	defer t.RUnlock()
+	mappedSet := newThreadSafeSetWithSize[T](t.uss.Cardinality())
+	for elem := range *t.uss {
+		if cb(elem) {
+			mappedSet.uss.add(elem)
+		}
+	}
+	return mappedSet
+}
+
 func (t *threadSafeSet[T]) Iter() <-chan T {
 	ch := make(chan T)
 	go func() {

--- a/threadsafe_test.go
+++ b/threadsafe_test.go
@@ -440,6 +440,45 @@ func Test_EachConcurrent(t *testing.T) {
 	}
 }
 
+func Test_FilterConcurrent(t *testing.T) {
+	runtime.GOMAXPROCS(2)
+	concurrent := 10
+
+	s := NewSet[int]()
+	ints := rand.Perm(N)
+	for _, v := range ints {
+		s.Add(v)
+	}
+
+	var count int64
+	wg := new(sync.WaitGroup)
+	wg.Add(concurrent)
+	for n := 0; n < concurrent; n++ {
+		go func() {
+			defer wg.Done()
+			mapped := s.Filter(func(elem int) bool {
+				atomic.AddInt64(&count, 1)
+				return elem%2 == 0
+			})
+			// Every retained element must be even and present in the source.
+			mapped.Each(func(elem int) bool {
+				if elem%2 != 0 {
+					t.Errorf("Filter produced odd element %d", elem)
+				}
+				if !s.Contains(elem) {
+					t.Errorf("Filter produced element %d not in source", elem)
+				}
+				return false
+			})
+		}()
+	}
+	wg.Wait()
+
+	if count != int64(N*concurrent) {
+		t.Errorf("%v != %v", count, int64(N*concurrent))
+	}
+}
+
 func Test_IterConcurrent(t *testing.T) {
 	runtime.GOMAXPROCS(2)
 

--- a/threadunsafe.go
+++ b/threadunsafe.go
@@ -158,6 +158,16 @@ func (s *threadUnsafeSet[T]) Each(cb func(T) bool) {
 	}
 }
 
+func (s *threadUnsafeSet[T]) Filter(cb func(T) bool) Set[T] {
+	mappedSet := newThreadUnsafeSetWithSize[T](s.Cardinality())
+	for elem := range *s {
+		if cb(elem) {
+			mappedSet.add(elem)
+		}
+	}
+	return mappedSet
+}
+
 func (s *threadUnsafeSet[T]) Equal(other Set[T]) bool {
 	o := other.(*threadUnsafeSet[T])
 


### PR DESCRIPTION
## Summary

Adds a new `Filter(func(T) bool) Set[T]` method to the `Set` interface, providing a built-in way to derive a filtered subset based on an arbitrary predicate.

The provided function is invoked against every element in the source set, and a new set is returned containing only the elements for which the function returned `true`. The source set is left unmodified. This abstracts and generalizes a common pattern that previously required callers to manually iterate (`Each` / `Iter`) and accumulate results into a new set.

## Example

```go
s := mapset.NewSet(1, 2, 3, 4, 5, 6)

evens := s.Filter(func(n int) bool {
    return n%2 == 0
})
// evens => {2, 4, 6}
// s     => unchanged
```

## Behavior
- Returns a new `Set[T]` of the same underlying type as the receiver; the source set is never mutated.
- Visits every element exactly once; iteration order is unspecified.
- Predicate returning true for all elements yields a clone; returning false for all yields an empty set; an empty source yields an empty set.
- The thread-safe implementation holds a read lock for the duration of the iteration, matching the locking semantics of `Each`.
