### PR TITLE
use maps.Clone() in Go 1.21+

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -1,0 +1,11 @@
+//go:build !go1.21
+
+package mapset
+
+func mapclone[T comparable](m map[T]struct{}) map[T]struct{} {
+	c := make(map[T]struct{}, len(m))
+	for k := range m {
+		c[k] = struct{}{}
+	}
+	return c
+}

--- a/helper_1_21.go
+++ b/helper_1_21.go
@@ -1,0 +1,9 @@
+//go:build go1.21
+
+package mapset
+
+import "maps"
+
+func mapclone[T comparable](m map[T]struct{}) map[T]struct{} {
+	return maps.Clone(m)
+}

--- a/threadunsafe.go
+++ b/threadunsafe.go
@@ -82,11 +82,8 @@ func (s *threadUnsafeSet[T]) Clear() {
 }
 
 func (s *threadUnsafeSet[T]) Clone() Set[T] {
-	clonedSet := newThreadUnsafeSetWithSize[T](s.Cardinality())
-	for elem := range *s {
-		clonedSet.add(elem)
-	}
-	return clonedSet
+	t := threadUnsafeSet[T](mapclone(*s))
+	return &t
 }
 
 func (s *threadUnsafeSet[T]) Contains(v ...T) bool {


### PR DESCRIPTION
This PR refactors the code to leverage Go 1.21's new standard library functions instead of custom implementations for these common map operations.

Utilize the standard library's `maps.Clone()` functions (available in Go 1.21+) for map cloning and comparison operations in the `threadUnsafeSet` type's `Clone()` method.


# Benchmark
## Before
```
BenchmarkClone1Safe-10                      	12673461	        94.19 ns/op	     232 B/op	       4 allocs/op
BenchmarkClone1Unsafe-10                    	15080484	        79.49 ns/op	     200 B/op	       3 allocs/op
BenchmarkClone10Safe-10                     	 4733935	       256.4 ns/op	     416 B/op	       6 allocs/op
BenchmarkClone10Unsafe-10                   	 4926964	       236.9 ns/op	     384 B/op	       5 allocs/op
BenchmarkClone100Safe-10                    	  723297	      1627 ns/op	    2432 B/op	       6 allocs/op
BenchmarkClone100Unsafe-10                  	  770386	      1621 ns/op	    2400 B/op	       5 allocs/op
```

## After
```
BenchmarkClone1Safe-10                      	19098370	        64.44 ns/op	     232 B/op	       4 allocs/op
BenchmarkClone1Unsafe-10                    	24963788	        46.46 ns/op	     200 B/op	       3 allocs/op
BenchmarkClone10Safe-10                     	11568508	       107.5 ns/op	     416 B/op	       6 allocs/op
BenchmarkClone10Unsafe-10                   	12565438	        91.67 ns/op	     384 B/op	       5 allocs/op
BenchmarkClone100Safe-10                    	 3827022	       344.8 ns/op	    2432 B/op	       6 allocs/op
BenchmarkClone100Unsafe-10                  	 3946198	       310.7 ns/op	    2400 B/op	       5 allocs/op

```
