### PR TITLE
Update and use last 3 major versions for CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x, 1.22.x, 1.23.x, 1.24.x]
+        go-version: [1.24.x, 1.25.x, 1.26.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Going forward, let's just stick to building on the last 3 major versions of Go.
- Updates the `workflows/ci.yaml` file.