### PR TITLE
feat: add IsDisjoint method to Set interface

### DIFF
--- a/set.go
+++ b/set.go
@@ -141,6 +141,16 @@ type Set[T comparable] interface {
 	// panic.
 	IsSubset(other Set[T]) bool
 
+	// IsDisjoint determines if this set and the other set have
+	// no elements in common. Returns true if the two sets are
+	// disjoint (no common elements), false otherwise.
+	//
+	// Note that the argument to IsDisjoint
+	// must be of the same type as the receiver
+	// of the method. Otherwise, IsDisjoint will
+	// panic.
+	IsDisjoint(other Set[T]) bool
+
 	// IsSuperset determines if every element in the other set
 	// is in this set.
 	//

--- a/set_test.go
+++ b/set_test.go
@@ -594,6 +594,114 @@ func Test_UnsafeSetIsProperSubset(t *testing.T) {
 	}
 }
 
+func Test_SetIsDisjoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        Set[int]
+		b        Set[int]
+		expected bool
+	}{
+		{
+			name:     "完全不相交",
+			a:        NewSet(1, 2),
+			b:        NewSet(3, 4),
+			expected: true,
+		},
+		{
+			name:     "有交集",
+			a:        NewSet(1, 2),
+			b:        NewSet(2, 3),
+			expected: false,
+		},
+		{
+			name:     "第一个为空",
+			a:        NewSet[int](),
+			b:        NewSet(1, 2),
+			expected: true,
+		},
+		{
+			name:     "第二个为空",
+			a:        NewSet(1, 2),
+			b:        NewSet[int](),
+			expected: true,
+		},
+		{
+			name:     "两个都为空",
+			a:        NewSet[int](),
+			b:        NewSet[int](),
+			expected: true,
+		},
+		{
+			name:     "两个完全相同的非空集合",
+			a:        NewSet(1, 2, 3),
+			b:        NewSet(1, 2, 3),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.a.IsDisjoint(tt.b); got != tt.expected {
+				t.Errorf("IsDisjoint() = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func Test_UnsafeSetIsDisjoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        Set[int]
+		b        Set[int]
+		expected bool
+	}{
+		{
+			name:     "完全不相交",
+			a:        NewThreadUnsafeSet(1, 2),
+			b:        NewThreadUnsafeSet(3, 4),
+			expected: true,
+		},
+		{
+			name:     "有交集",
+			a:        NewThreadUnsafeSet(1, 2),
+			b:        NewThreadUnsafeSet(2, 3),
+			expected: false,
+		},
+		{
+			name:     "第一个为空",
+			a:        NewThreadUnsafeSet[int](),
+			b:        NewThreadUnsafeSet(1, 2),
+			expected: true,
+		},
+		{
+			name:     "第二个为空",
+			a:        NewThreadUnsafeSet(1, 2),
+			b:        NewThreadUnsafeSet[int](),
+			expected: true,
+		},
+		{
+			name:     "两个都为空",
+			a:        NewThreadUnsafeSet[int](),
+			b:        NewThreadUnsafeSet[int](),
+			expected: true,
+		},
+		{
+			name:     "两个完全相同的非空集合",
+			a:        NewThreadUnsafeSet(1, 2, 3),
+			b:        NewThreadUnsafeSet(1, 2, 3),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.a.IsDisjoint(tt.b); got != tt.expected {
+				t.Errorf("IsDisjoint() = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}
+
 func Test_SetIsSuperset(t *testing.T) {
 	a := NewSet[int]()
 	a.Add(9)

--- a/threadsafe.go
+++ b/threadsafe.go
@@ -115,6 +115,18 @@ func (t *threadSafeSet[T]) IsSubset(other Set[T]) bool {
 	return ret
 }
 
+func (t *threadSafeSet[T]) IsDisjoint(other Set[T]) bool {
+	o := other.(*threadSafeSet[T])
+
+	t.RLock()
+	o.RLock()
+
+	ret := t.uss.IsDisjoint(o.uss)
+	t.RUnlock()
+	o.RUnlock()
+	return ret
+}
+
 func (t *threadSafeSet[T]) IsProperSubset(other Set[T]) bool {
 	o := other.(*threadSafeSet[T])
 

--- a/threadunsafe.go
+++ b/threadunsafe.go
@@ -231,6 +231,10 @@ func (s *threadUnsafeSet[T]) IsSubset(other Set[T]) bool {
 	return true
 }
 
+func (s *threadUnsafeSet[T]) IsDisjoint(other Set[T]) bool {
+	return !s.ContainsAnyElement(other)
+}
+
 func (s *threadUnsafeSet[T]) IsSuperset(other Set[T]) bool {
 	return other.IsSubset(s)
 }


### PR DESCRIPTION
## Summary

- Add `IsDisjoint(other Set[T]) bool` to the `Set` interface
- Returns true when the two sets share no elements (intersection is empty)
- Returns true when either or both sets are empty

## Implementation

- `threadunsafe.go`: delegates to `!s.ContainsAnyElement(other)` — reuses existing logic with no duplication
- `threadsafe.go`: acquires read locks on both sets before delegating to the unsafe implementation, following the exact locking pattern of `IsSubset`

## Test plan

- [x] Disjoint sets `{1,2}` and `{3,4}` → true
- [x] Overlapping sets `{1,2}` and `{2,3}` → false
- [x] First set empty → true
- [x] Second set empty → true
- [x] Both sets empty → true
- [x] Identical non-empty sets → false
- [x] Both threadsafe and threadunsafe implementations tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)