### PR TITLE
Call json.Marshal() directly in threadUnsafeSet[T].MarshalJSON()

### DIFF
--- a/bench_helper_test.go
+++ b/bench_helper_test.go
@@ -1,0 +1,49 @@
+package mapset
+
+import (
+	"fmt"
+	"math/rand"
+)
+
+func nrand(n int) []int {
+	is := make([]int, n)
+	for i := range is {
+		is[i] = rand.Int()
+	}
+	return is
+}
+
+func buildRandomSet(n int, safe bool) Set[int] {
+	if safe {
+		return NewSet(nrand(n)...)
+	} else {
+		return NewThreadUnsafeSet(nrand(n)...)
+	}
+}
+
+func buildCaseName(n int, safe bool) string {
+	var settype string
+	if safe {
+		settype = "Safe"
+	} else {
+		settype = "Unsafe"
+	}
+
+	return fmt.Sprintf("%s(%d)", settype, n)
+}
+
+type benchCase struct {
+	n    int
+	safe bool
+}
+
+func buildBenchCases(ns ...int) []benchCase {
+	cases := []benchCase{}
+	for _, n := range ns {
+		cases = append(cases, benchCase{n, true})
+	}
+	for _, n := range ns {
+		cases = append(cases, benchCase{n, false})
+	}
+	return cases
+}

--- a/bench_test.go
+++ b/bench_test.go
@@ -26,17 +26,8 @@ SOFTWARE.
 package mapset
 
 import (
-	"math/rand"
 	"testing"
 )
-
-func nrand(n int) []int {
-	i := make([]int, n)
-	for ind := range i {
-		i[ind] = rand.Int()
-	}
-	return i
-}
 
 func BenchmarkNewSet(b *testing.B) {
 	nums := nrand(1000)
@@ -835,4 +826,15 @@ func BenchmarkToSliceSafe(b *testing.B) {
 
 func BenchmarkToSliceUnsafe(b *testing.B) {
 	benchToSlice(b, NewThreadUnsafeSet[int]())
+}
+
+func BenchmarkMarshalJSON(b *testing.B) {
+	for _, c := range buildBenchCases(1, 10, 100) {
+		s := buildRandomSet(c.n, c.safe)
+		b.Run(buildCaseName(c.n, c.safe), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = s.MarshalJSON()
+			}
+		})
+	}
 }

--- a/threadunsafe.go
+++ b/threadunsafe.go
@@ -371,18 +371,7 @@ func (s threadUnsafeSet[T]) Union(other Set[T]) Set[T] {
 
 // MarshalJSON creates a JSON array from the set, it marshals all elements
 func (s threadUnsafeSet[T]) MarshalJSON() ([]byte, error) {
-	items := make([]string, 0, s.Cardinality())
-
-	for elem := range s {
-		b, err := json.Marshal(elem)
-		if err != nil {
-			return nil, err
-		}
-
-		items = append(items, string(b))
-	}
-
-	return []byte(fmt.Sprintf("[%s]", strings.Join(items, ","))), nil
+	return json.Marshal(s.ToSlice())
 }
 
 // UnmarshalJSON recreates a set from a JSON array, it only decodes


### PR DESCRIPTION
- call `json.Marshal()` directly in `threadUnsafeSet[T].MarshalJSON()`.
- add helper functions for benchmark.
   - using sub-benchmark (`b.Run()`) style.

# Benchmark
## Before
```
BenchmarkMarshalJSON/Safe(1)-10         	 7948977	       148.5 ns/op	     120 B/op	       6 allocs/op
BenchmarkMarshalJSON/Safe(10)-10        	 1439163	       837.2 ns/op	    1361 B/op	      35 allocs/op
BenchmarkMarshalJSON/Safe(100)-10       	  164941	      7453 ns/op	   13569 B/op	     305 allocs/op
BenchmarkMarshalJSON/Unsafe(1)-10       	 8391168	       142.8 ns/op	     120 B/op	       6 allocs/op
BenchmarkMarshalJSON/Unsafe(10)-10      	 1451538	       830.5 ns/op	    1361 B/op	      35 allocs/op
BenchmarkMarshalJSON/Unsafe(100)-10     	  166302	      7300 ns/op	   13568 B/op	     305 allocs/op
```

## After
```
BenchmarkMarshalJSON/Safe(1)-10         	11669055	       102.7 ns/op	      56 B/op	       3 allocs/op
BenchmarkMarshalJSON/Safe(10)-10        	 3923994	       306.7 ns/op	     312 B/op	       3 allocs/op
BenchmarkMarshalJSON/Safe(100)-10       	  528225	      2303 ns/op	    2970 B/op	       3 allocs/op
BenchmarkMarshalJSON/Unsafe(1)-10       	11849378	       101.6 ns/op	      56 B/op	       3 allocs/op
BenchmarkMarshalJSON/Unsafe(10)-10      	 3837678	       309.5 ns/op	     312 B/op	       3 allocs/op
BenchmarkMarshalJSON/Unsafe(100)-10     	  541398	      2247 ns/op	    2970 B/op	       3 allocs/op
```

- I will rewrite other benchmarks using this helpers if you accept this style.